### PR TITLE
Upgrade Django to 3.1.1.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,7 +11,7 @@ pylint = "*"
 pytest-mock = "*"
 
 [packages]
-Django = "==3.0.7"
+Django = "==3.1.1"
 requests = "*"
 django-reset-migrations = "*"
 django-import-export = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ac97b08d4799e2fc4d3f975af955134d458dea30aa1908fdb4e7a3956f34287a"
+            "sha256": "a848e1b39074f4ac7ab34a747dacb374524bf08aa0017209ed113febf6d445e7"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -183,11 +183,11 @@
         },
         "django": {
             "hashes": [
-                "sha256:5052b34b34b3425233c682e0e11d658fd6efd587d11335a0203d827224ada8f2",
-                "sha256:e1630333248c9b3d4e38f02093a26f1e07b271ca896d73097457996e0fae12e8"
+                "sha256:59c8125ca873ed3bdae9c12b146fbbd6ed8d0f743e4cf5f5817af50c51f1fc2f",
+                "sha256:b5fbb818e751f660fa2d576d9f40c34a4c615c8b48dd383f5216e609f383371f"
             ],
             "index": "pypi",
-            "version": "==3.0.7"
+            "version": "==3.1.1"
         },
         "django-admin-list-filter-dropdown": {
             "hashes": [

--- a/erp/models.py
+++ b/erp/models.py
@@ -973,7 +973,7 @@ class Accessibilite(models.Model):
     ##########################
     # Conformité             #
     ##########################
-    conformite = models.NullBooleanField(
+    conformite = models.BooleanField(
         verbose_name="Conformité",
         null=True,
         blank=True,


### PR DESCRIPTION
Release notes: 

- https://www.djangoproject.com/weblog/2020/aug/04/django-31-released/
- https://www.djangoproject.com/weblog/2020/sep/01/security-releases/