### PR TITLE
Restrict username format in public user registration form.

### DIFF
--- a/erp/forms.py
+++ b/erp/forms.py
@@ -5,9 +5,11 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.postgres.forms import SimpleArrayField
 from django.core.exceptions import ValidationError
+from django.core.validators import RegexValidator
 from django.forms import widgets
 from django.urls import reverse
 from django.utils.safestring import mark_safe
+
 
 from django_registration.forms import RegistrationFormUniqueEmail
 from requests.exceptions import RequestException
@@ -34,6 +36,10 @@ def get_widgets_for_accessibilite():
 
 
 class CustomRegistrationForm(RegistrationFormUniqueEmail):
+    USERNAME_RULES = (
+        "Uniquement des lettres, nombres et les caractères « . », « - » et « _ »"
+    )
+
     class Meta(RegistrationFormUniqueEmail.Meta):
         model = User
         fields = [
@@ -46,6 +52,13 @@ class CustomRegistrationForm(RegistrationFormUniqueEmail):
             "next",
         ]
 
+    username = forms.CharField(
+        max_length=32,
+        help_text=f"Requis. 32 caractères maximum. {USERNAME_RULES}.",
+        required=True,
+        label="Nom d’utilisateur",
+        validators=[RegexValidator(r"^[\w.-]+\Z", message=USERNAME_RULES,)],
+    )
     next = forms.CharField(required=False)
 
 

--- a/tests/erp/test_forms.py
+++ b/tests/erp/test_forms.py
@@ -7,6 +7,7 @@ from erp import schema
 from erp.forms import (
     AdminAccessibiliteForm,
     AdminErpForm,
+    CustomRegistrationForm,
     PublicErpEditInfosForm,
     ViewAccessibiliteForm,
 )
@@ -48,6 +49,32 @@ def fake_geocoder():
         "commune": "Paris",
         "code_insee": "75111",
     }
+
+
+@pytest.mark.django_db
+def test_CustomRegistrationForm():
+    form = CustomRegistrationForm()
+    assert form.is_valid() is False
+
+    form = CustomRegistrationForm({"username": "toto@toto.com"})
+    assert form.is_valid() is False
+    assert CustomRegistrationForm.USERNAME_RULES in form.errors["username"]
+
+    form = CustomRegistrationForm({"username": "toto+toto"})
+    assert form.is_valid() is False
+    assert CustomRegistrationForm.USERNAME_RULES in form.errors["username"]
+
+    form = CustomRegistrationForm(
+        {"username": "".join(map(lambda _: "x", range(0, 33)))}
+    )  # 33c length string
+    assert form.is_valid() is False
+    assert (
+        "Assurez-vous que cette valeur comporte au plus 32 caractères (actuellement 33)."
+        in form.errors["username"]
+    )
+
+    form = CustomRegistrationForm({"username": "jean-pierre.timbault_42"})
+    assert "username" not in form.errors
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
[Trello card](https://trello.com/c/MMDa79PN/290-emp%C3%AAcher-linscription-avec-un-nom-dutilisateur-username-au-format-adresse-email)