### PR TITLE
Better handle bad postcodes.

### DIFF
--- a/erp/forms.py
+++ b/erp/forms.py
@@ -177,11 +177,7 @@ class BaseErpForm(forms.ModelForm):
             self.raise_validation_error(
                 "code_postal",
                 mark_safe(
-                    f"""
-                    Cette adresse n'est pas localisable au code postal
-                    <a href="https://www.code-postal.com/{self.cleaned_data["code_postal"]}.html" target="_blank"
-                      title="Voir les communes pour ce code postal">
-                        {self.cleaned_data["code_postal"]}</a>"""
+                    f"Cette adresse n'est pas localisable au code postal {self.cleaned_data['code_postal']} (mais l'est au code {locdata['code_postal']})"
                 ),
             )
         if (

--- a/erp/geocoder.py
+++ b/erp/geocoder.py
@@ -31,6 +31,9 @@ def geocode(adresse):
             voie = properties.get("street")
         elif type == "locality":
             lieu_dit = properties.get("name")
+        # score
+        if properties["score"] < 0.5:
+            return None
         # coordinates
         geometry = feature["geometry"]
         return {

--- a/erp/geocoder.py
+++ b/erp/geocoder.py
@@ -1,5 +1,6 @@
 import requests
 
+from django.conf import settings
 from django.contrib.gis.geos import Point
 
 GEOCODER_URL = "https://api-adresse.data.gouv.fr/search/"
@@ -30,9 +31,6 @@ def geocode(adresse):
             voie = properties.get("street")
         elif type == "locality":
             lieu_dit = properties.get("name")
-        # score
-        if properties["score"] < 0.5:
-            return None
         # coordinates
         geometry = feature["geometry"]
         return {
@@ -51,6 +49,8 @@ def geocode(adresse):
 def query(params):
     try:
         res = requests.get(GEOCODER_URL, params)
+        if settings.DEBUG:
+            print("Geocoder URL", res.url)
         if res.status_code != 200:
             raise RuntimeError(
                 f"Erreur HTTP {res.status_code} lors de la géolocalisation de l'adresse."

--- a/tests/erp/test_forms.py
+++ b/tests/erp/test_forms.py
@@ -160,7 +160,8 @@ def test_BaseErpForm_clean_code_postal_mismatch(data, mocker):
     )
     assert form.is_valid() is False
     assert "code_postal" in form.errors
-    assert "pas localisable au code postal 75002" in form.errors["code_postal"][0]
+    assert "pas localisable au code postal" in form.errors["code_postal"][0]
+    assert "75002" in form.errors["code_postal"][0]
 
 
 @pytest.mark.django_db

--- a/tests/erp/test_forms.py
+++ b/tests/erp/test_forms.py
@@ -78,10 +78,10 @@ def test_CustomRegistrationForm():
 
 
 @pytest.mark.django_db
-def test_BaseErpForm_get_adresse(form_data, fake_geocoder, paris_commune):
+def test_BaseErpForm_get_adresse_query(form_data, fake_geocoder, paris_commune):
     form = AdminErpForm(form_data, geocode=fake_geocoder,)
     form.is_valid()  # populates cleaned_data
-    assert form.get_adresse() == "4 Rue de la Paix 75002 Paris"
+    assert form.get_adresse_query() == "4 Rue de la Paix 75 Paris"
 
 
 @pytest.mark.django_db

--- a/tests/erp/test_forms.py
+++ b/tests/erp/test_forms.py
@@ -160,8 +160,7 @@ def test_BaseErpForm_clean_code_postal_mismatch(data, mocker):
     )
     assert form.is_valid() is False
     assert "code_postal" in form.errors
-    assert "pas localisable au code postal" in form.errors["code_postal"][0]
-    assert "75002" in form.errors["code_postal"][0]
+    assert "pas localisable au code postal 75002" in form.errors["code_postal"][0]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
> Bonjour,
> J'ai trouvé l'établissement que je veux renseigner (siret 82250607700012).  Mais l'adresse rapatriée (5 Avenue DU PONT NEUF 74960 ANNECY) n'est pas reconnue.

Dans ce cas précis, il s'avère que l'API Sirene de L'INSEE nous expose l'adresse suivante pour l'établissement concerné : `5 Avenue DU PONT NEUF 74960 ANNECY`, mais le problème c'est que `74960` n'est pas le code postal d'Annecy, mais celui de Cran-Gevrier (ville juste à côté).

Ce faisant, la requête envoyée vers la BAN pour géolocaliser l'adresse renvoie un résultat peu pertinent du fait de ce code  erroné.

Partant du constat que les données issues du registre Sirene ne sont pas forcément fiables ou actualisées au niveau du code postal, ce patch tronque ce dernier pour n'en retenir que les deux premiers caractères, matérialisant le département, et fournit donc une requête à la BAN plus propice à renvoyer les bons résultats.

Le patch ajoute également un indice quand au code postal escompté, laissant cependant la charge de la modification de la saisie corrective à l'utilisateur :

![image](https://user-images.githubusercontent.com/41547/95357397-1bee1000-08c8-11eb-8982-b20b9c3484ca.png)
