### PR TITLE
Expose a compact step selector for handset viewports.

### DIFF
--- a/templates/contrib/base.html
+++ b/templates/contrib/base.html
@@ -8,7 +8,56 @@
     {% block contrib_content %}{% endblock %}
   </div>
   <nav class="col-md-3 mb-3">
-    <ul class="StepProgress">
+    <div class="d-md-none" id="step-navigation">
+      <label for="step-select" class="font-weight-bold">Navigation</label>
+      <select id="step-select" class="form-control" onchange="location=$(this).val()+'#step-navigation'">
+        <option {% if erp %}value="{% url "contrib_edit_infos" erp_slug=erp.slug %}"{% else %}value="{% url "contrib_start" %}"{% endif %}
+          {% if step == 1 %}selected{% endif %}>
+          {% if step > 1 %}[ok]{% endif %}
+          Informations
+        </option>
+        <option {% if erp %}value="{% url "contrib_transport" erp_slug=erp.slug %}"{% else %}disabled{% endif %}
+          {% if step == 2 %}selected{% endif %}>
+          {% if step > 2 %}[ok]{% endif %}
+          Venir dans l'établissement
+        </option>
+        <option {% if erp %}value="{% url "contrib_exterieur" erp_slug=erp.slug %}"{% else %}disabled{% endif %}
+          {% if step == 3 %}selected{% endif %}>
+          {% if step > 3 %}[ok]{% endif %}
+          Atteindre l'entrée
+        </option>
+        <option {% if erp %}value="{% url "contrib_entree" erp_slug=erp.slug %}"{% else %}disabled{% endif %}
+          {% if step == 4 %}selected{% endif %}>
+          {% if step > 4 %}[ok]{% endif %}
+          Entrée
+        </option>
+        <option {% if erp %}value="{% url "contrib_accueil" erp_slug=erp.slug %}"{% else %}disabled{% endif %}
+          {% if step == 5 %}selected{% endif %}>
+          {% if step > 5 %}[ok]{% endif %}
+          Accueil
+        </option>
+        <option {% if erp %}value="{% url "contrib_sanitaires" erp_slug=erp.slug %}"{% else %}disabled{% endif %}
+          {% if step == 6 %}selected{% endif %}>
+          {% if step > 6 %}[ok]{% endif %}
+          Sanitaires
+        </option>
+        <option {% if erp %}value="{% url "contrib_labellisation" erp_slug=erp.slug %}"{% else %}disabled{% endif %}
+          {% if step == 7 %}selected{% endif %}>
+          {% if step > 7 %}[ok]{% endif %}
+          Labellisation
+        </option>
+        <option {% if erp %}value="{% url "contrib_commentaire" erp_slug=erp.slug %}"{% else %}disabled{% endif %}
+          {% if step == 8 %}selected{% endif %}>
+          {% if step > 8 %}[ok]{% endif %}
+          Commentaire
+        </option>
+        <option {% if erp and erp.user == request.user %}value="{% url "contrib_publication" erp_slug=erp.slug %}"{% else %}disabled{% endif %}
+          {% if step == 9 %}selected{% endif %}>
+          Publication
+        </option>
+      </select>
+    </div>
+    <ul class="d-none d-md-block StepProgress">
       <li class="StepProgress-item{% if step == 1 %} current{% endif %}{% if step > 1 %} is-done{% endif %}">
         {% if erp %}
         <a href="{% url "contrib_edit_infos" erp_slug=erp.slug %}">Informations</a>


### PR DESCRIPTION
[Trello card](https://trello.com/c/n9FKBgD0/330-nafficher-que-l%C3%A9tape-en-cours-en-vue-mobile)

## Deskop view

![image](https://user-images.githubusercontent.com/41547/96844632-047a5f80-1450-11eb-95a3-8a5f8f85300d.png)

## Mobile view

![image](https://user-images.githubusercontent.com/41547/96844695-18be5c80-1450-11eb-804f-6ed63663124d.png)
