### PR TITLE
Fix error when a versioned object is empty.

### DIFF
--- a/erp/versioning.py
+++ b/erp/versioning.py
@@ -20,7 +20,7 @@ def extract_online_erp(version):
         if version.content_type == ContentType.objects.get_for_model(Erp)
         else version.object.erp
     )
-    if erp.is_online():
+    if erp and erp.is_online():
         return erp
     else:
         return None


### PR DESCRIPTION
Sentry issue : https://sentry.data.gouv.fr/access4all/access4all-django/issues/1893350/

> `error'NoneType' object has no attribute 'is_online'`
> erp/versioning.py in extract_online_erp at line 23

This might occur when a versioned object has been deleted.