### PR TITLE
Revamp contrib workflow navigation links.

### DIFF
--- a/erp/views.py
+++ b/erp/views.py
@@ -697,16 +697,27 @@ def process_accessibilite_form(
             messages.add_message(
                 request, messages.SUCCESS, "Les données ont été enregistrées."
             )
-            action = request.POST.get("action")
-            if action == "contribute":
-                hash = "#" + redirect_hash if redirect_hash else ""
-                return redirect(erp.get_absolute_url() + hash)
-            else:
+            # N'amener l'utilisateur vers l'étape de publication que:
+            # - s'il est propriétaire de la fiche
+            # - ou s'il est à une étape antérieure à celle qui amène à la gestion de la publication
+            if request.user == erp.user or step != 8:
                 return redirect(
                     reverse(redirect_route, kwargs={"erp_slug": erp.slug}) + "#content"
                 )
+            else:
+                return redirect(erp.get_absolute_url() + f"#{redirect_hash}")
     else:
         form = forms.AdminAccessibiliteForm(instance=accessibilite)
+
+    if prev_route:
+        prev_route = reverse(prev_route, kwargs={"erp_slug": erp.slug})
+    else:
+        prev_route = None
+
+    if request.user == erp.user or step != 8:
+        next_route = reverse(redirect_route, kwargs={"erp_slug": erp.slug})
+    else:
+        next_route = None
 
     return render(
         request,
@@ -716,9 +727,9 @@ def process_accessibilite_form(
             "erp": erp,
             "form": form,
             "accessibilite": accessibilite,
-            "prev_route": reverse(prev_route, kwargs={"erp_slug": erp.slug})
-            if prev_route
-            else None,
+            "redirect_hash": redirect_hash,
+            "next_route": next_route,
+            "prev_route": prev_route,
         },
     )
 

--- a/erp/views.py
+++ b/erp/views.py
@@ -684,6 +684,12 @@ def process_accessibilite_form(
         slug=erp_slug,
     )
     accessibilite = erp.accessibilite if hasattr(erp, "accessibilite") else None
+
+    # N'amener l'utilisateur vers l'étape de publication que:
+    # - s'il est propriétaire de la fiche
+    # - ou s'il est à une étape antérieure à celle qui amène à la gestion de la publication
+    user_can_access_next_route = request.user == erp.user or step != 8
+
     if request.method == "POST":
         Form = modelform_factory(
             Accessibilite, form=forms.AdminAccessibiliteForm, fields=form_fields
@@ -697,10 +703,7 @@ def process_accessibilite_form(
             messages.add_message(
                 request, messages.SUCCESS, "Les données ont été enregistrées."
             )
-            # N'amener l'utilisateur vers l'étape de publication que:
-            # - s'il est propriétaire de la fiche
-            # - ou s'il est à une étape antérieure à celle qui amène à la gestion de la publication
-            if request.user == erp.user or step != 8:
+            if user_can_access_next_route:
                 return redirect(
                     reverse(redirect_route, kwargs={"erp_slug": erp.slug}) + "#content"
                 )
@@ -714,7 +717,7 @@ def process_accessibilite_form(
     else:
         prev_route = None
 
-    if request.user == erp.user or step != 8:
+    if user_can_access_next_route:
         next_route = reverse(redirect_route, kwargs={"erp_slug": erp.slug})
     else:
         next_route = None

--- a/templates/contrib/1-admin-infos.html
+++ b/templates/contrib/1-admin-infos.html
@@ -144,9 +144,7 @@
         {{ form.contact_email|as_crispy_field }}
       </div>
     </div>
-    {% if erp and erp.user != request.user %}
-      <a class="btn btn-link" href="{{ erp.get_absolute_url }}">Revenir à la fiche</a>
-    {% endif %}
-    <button type="submit" class="btn btn-primary mr-2">Suivant</button>
+
+    {% include "contrib/includes/prevnext.html" with save_btn_label="Continuer" %}
   </form>
 {% endblock %}

--- a/templates/contrib/2-localisation.html
+++ b/templates/contrib/2-localisation.html
@@ -33,15 +33,12 @@
     {{ form.lat|as_crispy_field }}
     {{ form.lon|as_crispy_field }}
 
-    <p class="mt-3">
-      <a class="btn btn-link" href="{% url "contrib_edit_infos" erp_slug=erp.slug %}">Précédent</a>
-      {% if erp.user == request.user %}
-      <button type="submit" class="btn btn-primary mr-2">Suivant</button>
-      {% else %}
-      <a class="btn btn-link" href="{{ erp.get_absolute_url }}">Revenir à la fiche</a>
-      <button type="submit" name="action" value="contribute" class="btn btn-primary mr-2">Publier les modifications</button>
-      {% endif %}
-    </p>
+
+    <div class="mt-3">
+      {% url "contrib_edit_infos" erp_slug=erp.slug as prev_route %}
+      {% url "contrib_transport" erp_slug=erp.slug as next_route %}
+      {% include "contrib/includes/prevnext.html" %}
+    </div>
   </form>
 
   <script>

--- a/templates/contrib/base_access_form.html
+++ b/templates/contrib/base_access_form.html
@@ -61,17 +61,7 @@
 
     {% block fields_content %}{% endblock %}
 
-    <p>
-    {% if erp.user == request.user %}
-      {% if prev_route %}
-      <a class="btn btn-link" href="{{ prev_route }}">Précédent</a>
-      {% endif %}
-      <button type="submit" class="btn btn-primary">Suivant</button>
-    {% else %}
-      <a class="btn btn-link" href="{{ erp.get_absolute_url }}">Revenir à la fiche</a>
-      <button type="submit" name="action" value="contribute" class="btn btn-primary">Publier les modifications</button>
-    {% endif %}
-    </p>
+    {% include "contrib/includes/prevnext.html" %}
   </form>
   <script>
   window.addEventListener("DOMContentLoaded", function() {

--- a/templates/contrib/includes/prevnext.html
+++ b/templates/contrib/includes/prevnext.html
@@ -1,0 +1,18 @@
+<div class="d-flex flex-column d-lg-block">
+  {% if prev_route %}
+  <a class="btn btn-link" href="{{ prev_route }}">&laquo; Précédent</a>
+  {% endif %}
+
+  <button type="submit" class="btn btn-primary"
+    {% if erp.user != request.user %}name="action" value="contribute"{% endif %}>
+    {% if save_btn_label %}{{ save_btn_label }}{% else %}Enregister et continuer{% endif %}
+  </button>
+
+  {% if next_route %}
+  <a class="btn btn-link" href="{{ next_route }}">Suivant &raquo;</a>
+  {% endif %}
+
+  {% if erp and erp.is_online %}
+  <a class="btn btn-link" href="{{ erp.get_absolute_url }}">Revenir à la fiche</a>
+  {% endif %}
+</div>

--- a/tests/erp/test_browser.py
+++ b/tests/erp/test_browser.py
@@ -861,5 +861,8 @@ def test_contribution_flow_accessibilite_data(data, client):
     assert updated_erp.user == data.erp.user  # original owner is preserved
     assert updated_erp.accessibilite.sanitaires_presence is False
     assert updated_erp.accessibilite.sanitaires_adaptes is None
-    assert_redirect(response, updated_erp.get_absolute_url() + "#sanitaires")
+    assert_redirect(
+        response,
+        reverse("contrib_labellisation", kwargs={"erp_slug": updated_erp.slug}),
+    )
     assert response.status_code == 200


### PR DESCRIPTION
We don't have a Trello link but this is a blocking bug: contributors on an Erp don't have convenient navigation links for accessing previous and next steps in the contribution workflow. This patch attempts at "cleaning" existing links, make them responsive and ensure *previous* and *next* links are rendered every time they need to.