### PR TITLE
Update vaccination record mapper checks.

### DIFF
--- a/core/lib/text.py
+++ b/core/lib/text.py
@@ -10,6 +10,18 @@ def contains_digits(string):
     return any(char.isdigit() for char in string)
 
 
+def contains_sequence(test, source):
+    if not test or not source:
+        return False
+    return remove_accents(test.lower()) in remove_accents(source.lower())
+
+
+def contains_sequence_any(tests, source):
+    if not tests or not source:
+        return False
+    return any(contains_sequence(test, source) for test in tests)
+
+
 def normalize_nom(nom):
     parts = map(
         lambda x: x.title() if x not in FRENCH_STOPWORDS else x,

--- a/tests/core/test_text.py
+++ b/tests/core/test_text.py
@@ -18,6 +18,30 @@ def test_contains_digits(value, expected):
 
 
 @pytest.mark.parametrize(
+    "test, source, expected",
+    [
+        ("", "", False),
+        ("", "x", False),
+        ("bar", "foo bar baz", True),
+        ("baz", "foo bar baz", True),
+        ("foo bar", "foo bar baz", True),
+        ("foo bar", "Foo Bar", True),
+        ("fôÔ Bar", "FöÔ bÂr Bâz", True),
+        ("foo baz", "foo bar", False),
+        ("foo bar", "foobar", False),
+    ],
+)
+def test_contains_sequence(test, source, expected):
+    assert text.contains_sequence(test, source) is expected
+
+
+def test_contains_sequence_any():
+    assert text.contains_sequence_any(["foo", "baz"], "föo bâr bÄz") is True
+    assert text.contains_sequence_any(["foo", "nope"], "föo bâr bÄz") is True
+    assert text.contains_sequence_any(["nope", "nope"], "föo bâr bÄz") is False
+
+
+@pytest.mark.parametrize(
     "value, expected",
     [
         ("", ""),


### PR DESCRIPTION
We keep importing vaccination centers reserved to professionals and "équipes mobiles", while we shouldn't. 

To prevent these imports, this patch: 

- adds a few more rules and checks for professionals and équipes mobiles;
- checks presence of these rules in both `nom` and `modalites` fields.
 