### PR TITLE
Avoid overriding contributor comments when importing VC updates.

### DIFF
--- a/erp/mapper/vaccination.py
+++ b/erp/mapper/vaccination.py
@@ -73,13 +73,11 @@ class RecordMapper:
         # Save erp instance
         self.erp.save()
 
-        # Attach a comment to the Accessibilite object
-        if self.erp_exists and self.erp.has_accessibilite():
-            accessibilite = self.erp.accessibilite
-        else:
+        # Attach an Accessibilite to newly created Erps
+        if not self.erp.has_accessibilite():
             accessibilite = Accessibilite(erp=self.erp)
-        accessibilite.commentaire = commentaire
-        accessibilite.save()
+            accessibilite.commentaire = commentaire
+            accessibilite.save()
 
         return self.erp
 

--- a/tests/erp/mapper/test_vaccination.py
+++ b/tests/erp/mapper/test_vaccination.py
@@ -158,6 +158,8 @@ def test_save_non_existing_erp(activite_cdv, neufchateau, sample_record_ok):
 def test_update_existing_erp(activite_cdv, neufchateau, sample_record_ok):
     m1 = RecordMapper(sample_record_ok, today=datetime(2021, 1, 1))
     erp1 = m1.process(activite_cdv)
+    erp1.accessibilite.commentaire = "user contrib"
+    erp1.accessibilite.save()
 
     # import updated data for the same Erp
     sample_record_ok_updated = sample_record_ok.copy()
@@ -167,10 +169,7 @@ def test_update_existing_erp(activite_cdv, neufchateau, sample_record_ok):
 
     assert erp1.id == erp2.id
     assert erp2.telephone == "1234"
-    assert (
-        "mises à jour depuis data.gouv.fr le 01/01/2021"
-        in erp2.accessibilite.commentaire
-    )
+    assert "user contrib" in erp2.accessibilite.commentaire
 
 
 def test_unpublish_closed_erp(activite_cdv, neufchateau, sample_record_ok):


### PR DESCRIPTION
[Trello](https://trello.com/c/0RjV5z3P/561-ne-pas-%C3%A9craser-les-commentaires-saisis-par-les-gestionnaires-de-centres-de-vaccination)