### PR TITLE
Improve commune centered search

### DIFF
--- a/erp/managers.py
+++ b/erp/managers.py
@@ -80,7 +80,7 @@ class CommuneQuerySet(models.QuerySet):
                 )
                 clauses = (
                     clauses
-                    | Q(nom__unaccent__iexact=term)
+                    | Q(nom__unaccent__icontains=term)
                     | Q(**{f"{similarity_field}__gte": 0.6})
                 )
         return qs.filter(clauses)
@@ -212,7 +212,7 @@ class ErpQuerySet(models.QuerySet):
                 )
                 clauses = (
                     clauses
-                    | Q(commune_ext__nom__unaccent__iexact=term)
+                    | Q(commune_ext__nom__unaccent__icontains=term)
                     | Q(**{f"{similarity_field}__gte": 0.6})
                 )
         return qs.filter(clauses)

--- a/erp/managers.py
+++ b/erp/managers.py
@@ -228,7 +228,7 @@ class ErpQuerySet(models.QuerySet):
         Params:
         - raw_q: a raw query to search (eg. "lyon"); this is typically the raw input
           submitted by the user when using the public search form.
-        - qualified_q: a qualified query, usually resovled by the autocomplete frontend
+        - qualified_q: a qualified query, usually resolved by the autocomplete frontend
           code, featuring either:
           * a code_insee (34120) for a commune lookup
           * a departement (34, 2B) for a departement lookup
@@ -257,6 +257,13 @@ class ErpQuerySet(models.QuerySet):
         elif (
             qualified_q and len(qualified_q) == 5 and qualified_q.isdigit()
         ):  # code insee
+            # qs = (
+            #     qs
+            #     # .filter(commune_ext__code_insee=qualified_q)
+            #     .annotate(
+            #         distance=GeometryDistance("geom", F("commune_ext__geom"))
+            #     ).order_by("distance")
+            # )
             qs = qs.filter(commune_ext__code_insee=qualified_q)
         return qs
 

--- a/erp/provider/departements.py
+++ b/erp/provider/departements.py
@@ -426,7 +426,7 @@ def search(q, limit=None, for_autocomplete=False, keep_scores=False):
     seen_codes = []
     for code, dpt in get_departements().items():
         score = 0
-        if code in seen_codes:
+        if code in seen_codes or code in ["75"]:  # Paris city IS a departement
             continue
         if _to_phrase(q) == _to_phrase(dpt["nom"]):
             score = 1

--- a/erp/templatetags/a4a.py
+++ b/erp/templatetags/a4a.py
@@ -82,6 +82,8 @@ def encode_provider_data(value):
 def format_distance(value):
     if isinstance(value, str):
         return value
+    elif isinstance(value, float):
+        return str(value)
     if value.m == 0:
         return "Au même endroit"
     elif value.m < 1500:

--- a/static/js/dom.js
+++ b/static/js/dom.js
@@ -22,6 +22,10 @@ function mountAll(selector, fn) {
   findAll(selector).forEach(fn);
 }
 
+function preventDefault(event) {
+  event.preventDefault();
+}
+
 function ready(fn) {
   window.addEventListener("DOMContentLoaded", fn);
 }
@@ -46,6 +50,7 @@ export default {
   hide,
   mountAll,
   mountOne,
+  preventDefault,
   ready,
   removeClass,
   show,

--- a/static/js/ui/SearchWhere.js
+++ b/static/js/ui/SearchWhere.js
@@ -1,4 +1,5 @@
 import api from "../api";
+import dom from "../dom";
 import Autocomplete from "@trevoreyre/autocomplete-js";
 
 async function getCommonResults(loc) {
@@ -43,7 +44,9 @@ function SearchWhere(root) {
         if (api.hasPermission("geolocation") !== "granted") {
           a11yGeolocBtn.focus();
         }
+        input.form.addEventListener("submit", dom.preventDefault);
         const loc = await api.loadUserLocation();
+        input.form.removeEventListener("submit", dom.preventDefault);
         if (!loc) {
           console.warn("Impossible de récupérer votre localisation ; vérifiez les autorisations de votre navigateur");
           setLatLon(null);

--- a/templates/search/form.html
+++ b/templates/search/form.html
@@ -10,10 +10,10 @@
       </label>
       <div class="search-where-field" style="z-index:9999">
         <input id="where-input" class="autocomplete-input form-control" type="search" dir="ltr"
-          spellcheck=false autocomplete="off" autocapitalize="off" value="{{ search_where_label }}"
-          name="search_where_label" placeholder="Exemple: lyon, rhône" data-src="{% url "where" %}">
+          spellcheck=false autocomplete="off" autocapitalize="off" value="{{ where_label }}"
+          name="where_label" placeholder="Exemple: lyon, rhône" data-src="{% url "where" %}">
         <ul class="list-group autocomplete-result-list rounded-only-bottom"></ul>
-        <input type="hidden" name="where" value="{{ search_where }}">
+        <input type="hidden" name="where" value="{{ where }}">
         <input type="hidden" name="lat" value="{{ lat }}">
         <input type="hidden" name="lon" value="{{ lon }}">
         <button type="button" class="sr-only get-geoloc-btn" tabindex="-1">
@@ -22,16 +22,16 @@
       </div>
     </div>
     <div class="what-field col-xl-6 py-1">
-      <label for="search_what">
+      <label for="what-input">
         <span class="sr-only">Saisir vos termes de recherche, par exemple un type de service</span>
         <strong aria-hidden="true" class="larger-font{% if dark %} text-light{% endif %}">Quoi</strong>
         <span aria-hidden="true" class="text-{% if dark %}light{% else %}muted{% endif %}">(activité, nom de l'établissement…)</span>
       </label>
       <div class="input-group">
-        <input type="search" id="search_what" name="what"
+        <input type="search" id="what-input" name="what"
           class="form-control" placeholder="Exemple: mairie, café…"
           aria-label="Rechercher un établissement, une activité" autocomplete="off"
-          value="{{ search_what|default_if_none:"" }}">
+          value="{{ what|default_if_none:"" }}">
         <div class="input-group-append">
           <button type="submit" class="btn {% if dark %}btn-light{% else %}btn-primary{% endif %} border-left text-nowrap">
             <i aria-hidden="true" class="icon icon-magnifying-glass a4a-icon-small-top"></i>

--- a/templates/search/results.html
+++ b/templates/search/results.html
@@ -3,7 +3,7 @@
 {% load a4a %}
 {% load static %}
 
-{% block page_title %}{% if pager %}Résultats pour {{ search_what }} {{ search_where_label }}{% else %}Aucun résultat{% endif %}{% endblock%}
+{% block page_title %}{% if pager %}Résultats pour {{ what }} {{ where_label }}{% else %}Aucun résultat{% endif %}{% endblock%}
 
 {% block header %}
   {% include "editorial/header.html" with dark=True %}
@@ -13,12 +13,12 @@
 <main id="content">
   <h2 class="mt-3 mb-2">
     <small class="text-muted" style="font-size:.6em">Votre recherche</small><br>
-    <span class="sr-only">Localité:</span> {{ search_where_label }}
-    {% if search_where_label and search_what %}<small class="text-muted">/</small>{% endif %}
-    {% if search_what %}<span class="sr-only">Activité: </span>{% endif %}{{ search_what }}
+    <span class="sr-only">Localité:</span> {{ where_label }}
+    {% if where_label and what %}<small class="text-muted">/</small>{% endif %}
+    {% if what %}<span class="sr-only">Activité: </span>{% endif %}{{ what }}
   </h2>
 
-  {% if search_what and "centres de vaccination" in search_what %}
+  {% if what and "centres de vaccination" in what %}
   <div class="alert alert-warning">
     Découvrez l'information d'accessibilité actuellement disponible pour chaque centre de vaccination (la collecte d'information est en cours).
     <br class="d-none d-md-block">
@@ -38,7 +38,7 @@
       <div class="col-sm-6">
         <h2 class="h4 m-0 mb-3">
           {{ paginator.count }} établissement{{ paginator.count|pluralize:"s" }}
-          {% if search_where == "around_me" %}à moins de 20km{% endif %}
+          {% if where == "around_me" %}à moins de 20km{% endif %}
           <small class="text-muted">{% if paginator.num_pages > 1 %}page {{ pager.number }}/{{ paginator.num_pages }}{% endif %}</small>
         </h2>
       </div>
@@ -58,7 +58,7 @@
                   <a href="{{ erp.get_absolute_url }}">
                     <img alt="{% if erp.activite %}{{ erp.activite }}{% endif %}" class="act-icon act-icon-20 mb-1"
                       src="{% static "img/mapicons.svg" %}#{{ erp.get_activite_vector_icon }}">
-                    {% if search_where == "around_me" and erp.distance %}
+                    {% if where == "around_me" and erp.distance %}
                       <small class="text-muted"><em>{{ erp.distance|format_distance }}</em></small>
                     {% endif %}
                     {{ erp.nom }}

--- a/tests/erp/export/test_export_unit.py
+++ b/tests/erp/export/test_export_unit.py
@@ -9,8 +9,17 @@ from erp.export.export import export_schema_to_csv
 from erp.export.generate_schema import generate_schema
 from erp.export.utils import map_erps_to_json_schema
 from erp.export.mappers import EtalabMapper
-from erp.models import Erp
-from tests.erp.test_managers import create_test_erp
+from erp.models import Accessibilite, Erp
+
+
+def create_test_erp(name, **a11y_data):
+    erp = Erp.objects.create(nom=name)
+    if a11y_data:
+        Accessibilite.objects.create(erp=erp, **a11y_data)
+    else:
+        # simulate the case we have a non-a11y field filled
+        Accessibilite.objects.create(erp=erp, commentaire="simple commentaire")
+    return erp
 
 
 @pytest.fixture

--- a/tests/erp/test_browser.py
+++ b/tests/erp/test_browser.py
@@ -34,8 +34,8 @@ def test_communes(data, client):
 
 def test_search_commune(data, client):
     response = client.get(reverse("search") + "?where=34120&what=croissant")
-    assert response.context["search_where"] == "34120"
-    assert response.context["search_what"] == "croissant"
+    assert response.context["where"] == "34120"
+    assert response.context["what"] == "croissant"
     assert len(response.context["pager"]) == 1
     assert response.context["pager"][0].nom == "Aux bons croissants"
     assert hasattr(response.context["pager"][0], "distance") is True
@@ -43,11 +43,11 @@ def test_search_commune(data, client):
 
 def test_search_raw_commune(data, client):
     response = client.get(
-        reverse("search") + "?search_where_label=jacou&where=&what=croissant"
+        reverse("search") + "?where_label=jacou&where=&what=croissant"
     )
-    assert response.context["search_where"] == ""
-    assert response.context["search_what"] == "croissant"
-    assert response.context["search_where_label"] == "jacou"
+    assert response.context["where"] == ""
+    assert response.context["what"] == "croissant"
+    assert response.context["where_label"] == "jacou"
     assert len(response.context["pager"]) == 1
     assert response.context["pager"][0].nom == "Aux bons croissants"
     assert hasattr(response.context["pager"][0], "distance") is False
@@ -55,9 +55,9 @@ def test_search_raw_commune(data, client):
 
 def test_search_departement(data, client):
     response = client.get(reverse("search") + "?where=34&what=croissant")
-    assert response.context["search_where"] == "34"
-    assert response.context["search_what"] == "croissant"
-    assert response.context["search_where_label"] == "Hérault"
+    assert response.context["where"] == "34"
+    assert response.context["what"] == "croissant"
+    assert response.context["where_label"] == "Hérault"
     assert len(response.context["pager"]) == 1
     assert response.context["pager"][0].nom == "Aux bons croissants"
     assert hasattr(response.context["pager"][0], "distance") is False
@@ -65,9 +65,9 @@ def test_search_departement(data, client):
 
 def test_search_empty_text_query(data, client):
     response = client.get(reverse("search") + "?where=&what=")
-    assert response.context["search_where"] == ""
-    assert response.context["search_where_label"] == "France entière"
-    assert response.context["search_what"] == ""
+    assert response.context["where"] == ""
+    assert response.context["where_label"] == "France entière"
+    assert response.context["what"] == ""
     assert response.context["pager"] is not None
 
 
@@ -76,8 +76,8 @@ def test_search_around_me(data, client):
         reverse("search")
         + "?where=around_me&what=croissant&lat=43.6648062&lon=3.9048148"
     )
-    assert response.context["search_where"] == "around_me"
-    assert response.context["search_what"] == "croissant"
+    assert response.context["where"] == "around_me"
+    assert response.context["what"] == "croissant"
     assert len(response.context["pager"]) == 1
     assert response.context["pager"][0].nom == "Aux bons croissants"
     assert hasattr(response.context["pager"][0], "distance")

--- a/tests/erp/test_browser.py
+++ b/tests/erp/test_browser.py
@@ -38,7 +38,7 @@ def test_search_commune(data, client):
     assert response.context["search_what"] == "croissant"
     assert len(response.context["pager"]) == 1
     assert response.context["pager"][0].nom == "Aux bons croissants"
-    assert hasattr(response.context["pager"][0], "distance") is False
+    assert hasattr(response.context["pager"][0], "distance") is True
 
 
 def test_search_raw_commune(data, client):

--- a/tests/erp/test_managers.py
+++ b/tests/erp/test_managers.py
@@ -1,75 +1,123 @@
 import pytest
 
+from django.contrib.gis.geos import Point
+
 from erp.models import Accessibilite, Erp
 from erp import schema
 
-# ErpQuerySet
+# ErpQuerySet#having_a11y_data
 
 
-def create_test_erp(name, **a11y_data):
-    erp = Erp.objects.create(nom=name)
-    if a11y_data:
-        Accessibilite.objects.create(erp=erp, **a11y_data)
-    else:
-        # simulate the case we have a non-a11y field filled
-        Accessibilite.objects.create(erp=erp, commentaire="simple commentaire")
-    return erp
+@pytest.fixture
+def erp_with_a11y(db):
+    def _factory(name, **a11y_data):
+        erp = Erp.objects.create(nom=name)
+        if a11y_data:
+            Accessibilite.objects.create(erp=erp, **a11y_data)
+        else:
+            # simulate the case we have a non-a11y field filled
+            Accessibilite.objects.create(erp=erp, commentaire="simple commentaire")
+        return erp
+
+    return _factory
 
 
-def test_ErpQuerySet_having_a11y_data_no_data(db):
-    create_test_erp("test")
+def test_ErpQuerySet_having_a11y_data_no_data(erp_with_a11y):
+    erp_with_a11y("test")
     assert Erp.objects.having_a11y_data().count() == 0
 
 
-def test_ErpQuerySet_having_a11y_data_boolean(db):
-    create_test_erp("test", sanitaires_presence=None)
+def test_ErpQuerySet_having_a11y_data_boolean(erp_with_a11y):
+    erp_with_a11y("test", sanitaires_presence=None)
     assert Erp.objects.having_a11y_data().count() == 0
 
-    create_test_erp("test", sanitaires_presence=True)
+    erp_with_a11y("test", sanitaires_presence=True)
     assert Erp.objects.having_a11y_data().count() == 1
 
-    create_test_erp("test", sanitaires_presence=False)
+    erp_with_a11y("test", sanitaires_presence=False)
     assert Erp.objects.having_a11y_data().count() == 2
 
 
-def test_ErpQuerySet_having_a11y_data_array(db):
-    create_test_erp("test")
+def test_ErpQuerySet_having_a11y_data_array(erp_with_a11y):
+    erp_with_a11y("test")
     assert Erp.objects.having_a11y_data().count() == 0
 
-    create_test_erp("test", accueil_equipements_malentendants=[])
+    erp_with_a11y("test", accueil_equipements_malentendants=[])
     assert Erp.objects.having_a11y_data().count() == 0
 
-    create_test_erp(
+    erp_with_a11y(
         "test",
         accueil_equipements_malentendants=[schema.EQUIPEMENT_MALENTENDANT_LPC],
     )
     assert Erp.objects.having_a11y_data().count() == 1
 
 
-def test_ErpQuerySet_having_a11y_data_string(db):
-    create_test_erp("test", transport_information="")
+def test_ErpQuerySet_having_a11y_data_string(erp_with_a11y):
+    erp_with_a11y("test", transport_information="")
     assert Erp.objects.having_a11y_data().count() == 0
 
-    create_test_erp("test", transport_information="coucou")
+    erp_with_a11y("test", transport_information="coucou")
     assert Erp.objects.having_a11y_data().count() == 1
 
 
-def test_ErpQuerySet_having_a11y_data_number(db):
-    create_test_erp("test", entree_marches=0)
+def test_ErpQuerySet_having_a11y_data_number(erp_with_a11y):
+    erp_with_a11y("test", entree_marches=0)
     assert Erp.objects.having_a11y_data().count() == 1
 
-    create_test_erp("test", entree_marches=1)
+    erp_with_a11y("test", entree_marches=1)
     assert Erp.objects.having_a11y_data().count() == 2
 
 
-def test_ErpQuerySet_having_a11y_data_accumulation(db):
-    create_test_erp("test1", accueil_retrecissement=True)
+def test_ErpQuerySet_having_a11y_data_accumulation(erp_with_a11y):
+    erp_with_a11y("test1", accueil_retrecissement=True)
     assert Erp.objects.having_a11y_data().count() == 1
 
-    create_test_erp("test2", sanitaires_presence=True)
+    erp_with_a11y("test2", sanitaires_presence=True)
     assert Erp.objects.having_a11y_data().count() == 2
 
-    create_test_erp("test3")
+    erp_with_a11y("test3")
     qs = Erp.objects.having_a11y_data()
     assert qs.count() == 2
     assert "test3" not in [e["nom"] for e in qs.values("nom")]
+
+
+# ErpQuerySet#nearest
+
+
+@pytest.fixture
+def erp_with_geom(db):
+    def _factory(name, lat, lon):
+        return Erp.objects.create(nom=name, geom=Point(x=lon, y=lat, srid=4326))
+
+    return _factory
+
+
+@pytest.fixture
+def paris_point():
+    return Point(x=2.352222, y=48.856613, srid=4326)
+
+
+@pytest.fixture
+def vendargues_point():
+    return Point(x=3.969950, y=43.656880, srid=4326)
+
+
+@pytest.fixture
+def jacou_erp(erp_with_geom):
+    return erp_with_geom("e1", 43.661060, 3.912700)
+
+
+def test_ErpQuerySet_nearest_point(jacou_erp, paris_point, vendargues_point):
+    assert Erp.objects.nearest(paris_point, max_radius_km=1).count() == 0
+    assert Erp.objects.nearest(paris_point, max_radius_km=1000).count() == 1
+    assert Erp.objects.nearest(paris_point, max_radius_km=1000).first() == jacou_erp
+
+    assert Erp.objects.nearest(vendargues_point, max_radius_km=5).count() == 1
+    assert Erp.objects.nearest(vendargues_point, max_radius_km=5).first() == jacou_erp
+
+
+def test_ErpQuerySet_nearest_tuple(jacou_erp, paris_point):
+    paris_tuple = (str(paris_point[1]), str(paris_point[0]))
+    assert Erp.objects.nearest(paris_tuple, max_radius_km=1).count() == 0
+    assert Erp.objects.nearest(paris_tuple, max_radius_km=1000).count() == 1
+    assert Erp.objects.nearest(paris_tuple, max_radius_km=1000).first() == jacou_erp


### PR DESCRIPTION
This patch improves the relevance of search queries by searching for results around the center of the city and ordering by ascending distances, so we can retrieve results in neighboring cities, which makes a better UX when there are very few (or no) results for a given city.