### PR TITLE
Get a label for form field, used in form.errors.

### DIFF
--- a/erp/forms.py
+++ b/erp/forms.py
@@ -639,3 +639,15 @@ class PublicClaimForm(forms.Form):
         required=True,
         label="Je m'engage sur l'honneur à fournir des informations factuelles sur cet établissement.",
     )
+
+
+FORM_FIELDS = {
+    "user_type": {"label": PublicAProposForm.declared_fields["user_type"].label},
+}
+
+
+def get_label(field, default=""):
+    try:
+        return FORM_FIELDS[field].get("label", default)
+    except KeyError:
+        return default

--- a/erp/templatetags/a4a.py
+++ b/erp/templatetags/a4a.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 
-from erp import schema, serializers
+from erp import forms, schema, serializers
 from erp.models import Erp
 from erp.provider import arrondissements, naf, sirene
 
@@ -173,9 +173,9 @@ def get_naf_label(value):
     return naf.get_naf_label(value, "inconnu")
 
 
-@register.filter(name="get_schema_label")
-def get_schema_label(value):
-    return schema.get_label(value)
+@register.filter(name="get_field_label")
+def get_field_label(value):
+    return schema.get_label(value) or forms.get_label(value)
 
 
 @register.filter("isemptylist")

--- a/templates/contrib/base_access_form.html
+++ b/templates/contrib/base_access_form.html
@@ -50,7 +50,7 @@
       Attention, des erreurs ont été rencontrées.
       <ul class="my-1">
         {% for field_name, message in form.errors.items %}
-        <li>{{ field_name|get_schema_label }}: {{ message }}</li>
+        <li>{{ field_name|get_field_label }}: {{ message }}</li>
         {% endfor %}
       </ul>
     </div>


### PR DESCRIPTION
@z3ntUx This is only a suggestion, I did the same we are doing for `schema`. You might have a better idea.