### PR TITLE
No more tag manager.

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -33,14 +33,6 @@
         {% endblock javascript_extras %}
         <meta name="google-site-verification"
               content="SPPq95ai4uSt5AL3H0POB1MjydYAMiBY6ReGBkC_ZFg">
-        <!-- Matomo Tag Manager -->
-        <script>
-      var _mtm = window._mtm = window._mtm || [];
-      _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
-      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-      g.async=true; g.src='https://stats.data.gouv.fr/js/container_zMRXlK5d.js'; s.parentNode.insertBefore(g,s);
-        </script>
-        <!-- End Matomo Tag Manager -->
     </head>
     <body class="a4a" tabindex="0">
         {% block skiplinks %}


### PR DESCRIPTION
Previously, we used matomo tag manager to integrate Crisp. Crisp is now integrated in our codebase, we don't need this tag manager anymore.