### PR TITLE
Update django.po

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -136,7 +136,7 @@ msgid "API"
 msgstr "API"
 
 msgid "Signaler une malveillance"
-msgstr "Report malicious intent"
+msgstr "Report a malicious act"
 
 msgid "Vaccination"
 msgstr "Vaccination"
@@ -174,7 +174,7 @@ msgstr "French"
 msgid "English"
 msgstr "English"
 
-msgid "Un mots-clé par ligne"
+msgid "Un mot-clé par ligne"
 msgstr "One keyword per line"
 
 msgid "Un code postal par ligne"
@@ -190,10 +190,10 @@ msgstr ""
 
 #, python-brace-format
 msgid "Cette adresse n'est pas localisable au code postal {code_postal} "
-msgstr "This address cannot be located in the postal code {code_postal}"
+msgstr "This address cannot be located at the postal code {code_postal}"
 
 msgid "Cette adresse n'est pas localisable au code INSEE {}"
-msgstr "This address cannot be located in the INSEE code {}"
+msgstr "This address cannot be located at the INSEE code {}"
 
 msgid "Activité"
 msgstr "Activity"
@@ -216,8 +216,7 @@ msgid ""
 "Supprimer cet établissement de la base de données (cette opération est "
 "irrémédiable)"
 msgstr ""
-"Delete this facility from the database (this operation is non "
-"revertable)"
+"Delete this facility from the database (this operation is irretrievable)"
 
 msgid "Recherche"
 msgstr "Search"
@@ -354,7 +353,7 @@ msgstr "Estimated number of inhabitants"
 msgid "Localisation"
 msgstr "Localisation"
 
-msgid "Coordonnées géographique du centre de la commune"
+msgid "Coordonnées géographiques du centre de la commune"
 msgstr "Geographical coordinates of the center of the municipality"
 
 msgid "Contour"
@@ -500,7 +499,7 @@ msgid "La commune de cet établissement"
 msgstr "The commune of this facility"
 
 msgid "Nom de l'établissement ou de l'enseigne"
-msgstr "Name of the facility or sign"
+msgstr "Name of the facility or business"
 
 msgid ""
 "Domaine d'activité de l'ERP. Attention, la recherche se fait sur les lettres"
@@ -573,7 +572,7 @@ msgid "Voie"
 msgstr "Street"
 
 msgid "Lieu dit"
-msgstr "Hamlet"
+msgstr "locality"
 
 msgid "Code postal"
 msgstr "Postal code"
@@ -585,7 +584,7 @@ msgid "Search vector"
 msgstr "Search vector"
 
 msgid "Email lié à l'import"
-msgstr "Email linked to the importation"
+msgstr "Email linked to the import"
 
 msgid ""
 "Adresse email permettant de relancer l'utilisateur lié à l'import de l'ERP"
@@ -595,7 +594,7 @@ msgid "Le code postal doit faire 5 caractères"
 msgstr "The postal code must be 5 characters long"
 
 msgid "Veuillez entrer une voie ou un lieu-dit"
-msgstr "Please enter a street or a hamlet"
+msgstr "Please enter a street or a locality"
 
 #, python-brace-format
 msgid "Commune {self.commune} introuvable, veuillez vérifier votre saisie."
@@ -611,28 +610,28 @@ msgid "ERP"
 msgstr "ERP"
 
 msgid "Desserte par transports en commun"
-msgstr "Public transport access"
+msgstr "Public transport service"
 
 msgid "Informations transports"
-msgstr "Transport information"
+msgstr "Transportation information"
 
 msgid "Stationnement dans l'ERP"
-msgstr "Parking in the ERP"
+msgstr "Parking within the ERP"
 
 msgid "Stationnements PMR dans l'ERP"
-msgstr "PRM parking in the ERP"
+msgstr "PRM parking within the ERP"
 
 msgid "Stationnement à proximité de l'ERP"
-msgstr "Parking near the ERP"
+msgstr "Parking next to the ERP"
 
 msgid "Stationnements PMR à proximité de l'ERP"
-msgstr "PRM parking near the ERP"
+msgstr "PRM parking next to the ERP"
 
 msgid "Espace extérieur"
 msgstr "Outdoor space"
 
 msgid "Cheminement de plain-pied"
-msgstr "Level walkway"
+msgstr "Ground-level walkway"
 
 msgid "Terrain meuble ou accidenté"
 msgstr "Soft or uneven ground"
@@ -644,7 +643,7 @@ msgid "Sens de circulation de l'escalier"
 msgstr "Direction of the staircase"
 
 msgid "Repérage des marches ou de l’escalier"
-msgstr "Locating the steps or staircase"
+msgstr "identification of the steps or staircase"
 
 msgid "Main courante"
 msgstr "Handrail"
@@ -665,13 +664,13 @@ msgid "Longueur de la pente"
 msgstr "Length of the slope"
 
 msgid "Dévers"
-msgstr "Spill"
+msgstr "camber"
 
 msgid "Bande de guidage"
-msgstr "Guide band"
+msgstr "Guide strip"
 
 msgid "Rétrécissement du cheminement"
-msgstr "Narrowing of the path"
+msgstr "Path narrowing"
 
 msgid "Entrée facilement repérable"
 msgstr "Easily identifiable entrance"
@@ -680,28 +679,28 @@ msgid "Y a-t-il une porte ?"
 msgstr "Is there a door?"
 
 msgid "Manœuvre de la porte"
-msgstr "Door operation"
+msgstr "Door handling"
 
 msgid "Type de porte"
 msgstr "Type of door"
 
 msgid "Entrée vitrée"
-msgstr "Glass entrance"
+msgstr "Glazed entrance"
 
 msgid "Vitrophanie"
-msgstr "Vitrophanie"
+msgstr "Window sticker"
 
 msgid "Entrée de plain-pied"
 msgstr "Ground level entrance"
 
 msgid "Marches d'escalier"
-msgstr "Stair treads"
+msgstr "Steps"
 
 msgid "Repérage de l'escalier"
-msgstr "Staircase location"
+msgstr "Steps identification"
 
 msgid "Présence d'une balise sonore"
-msgstr "Presence of a sound beacon"
+msgstr "Presence of an audio location signal"
 
 msgid "Dispositif d'appel"
 msgstr "Calling device"
@@ -740,7 +739,7 @@ msgid "Équipement(s) sourd/malentendant"
 msgstr "Deaf/hard of hearing equipment(s)"
 
 msgid "Cheminement de plain pied"
-msgstr "Level access road"
+msgstr "Ground-level pathway"
 
 msgid "Nombre de chambres accessibles"
 msgstr "Number of accessible rooms"
@@ -953,7 +952,7 @@ msgstr ""
 
 msgid "Avec équipement permanent, casques et boîtiers disponibles à l’accueil"
 msgstr ""
-"With permanent equipment, helmets and boxes available at the reception"
+"With permanent equipment, helmets and cases available at the reception"
 
 msgid ""
 "Avec équipement permanent nécessitant le téléchargement d'une application "
@@ -984,13 +983,13 @@ msgid "Tourniquet"
 msgstr "Turnstile"
 
 msgid "Porte tambour"
-msgstr "Drum door"
+msgstr "Revolving door"
 
 msgid "Aucune"
 msgstr "None"
 
 msgid "Fixe"
-msgstr "Fixed"
+msgstr "Stationary"
 
 msgid "Amovible"
 msgstr "Removable"
@@ -1008,7 +1007,7 @@ msgid "La RSE Positive"
 msgstr "Positive CSR"
 
 msgid "Mobalib, l'expert du handicap"
-msgstr "Mobalib, the disability expert"
+msgstr "Mobalib, l'expert du handicap"
 
 msgid "Expert en données d'accessibilité"
 msgstr "Accessibility data expert"
@@ -1045,7 +1044,7 @@ msgid "à proximité"
 msgstr "near"
 
 msgid "Chemin extérieur"
-msgstr "Exterior path"
+msgstr "Outside path"
 
 msgid "depuis la voirie jusqu'à l'entrée"
 msgstr "from the road to the entrance"
@@ -1105,7 +1104,7 @@ msgstr ""
 "important about the route from the stop to the facility."
 
 msgid "Informations sur l'accessibilité par les transports en commun"
-msgstr "Information on accessibility by public transport"
+msgstr "Information on accessibility by public transportation"
 
 msgid "Stationnement dans l'établissement"
 msgstr "Parking in the facility"
@@ -1193,7 +1192,7 @@ msgid ""
 "bâtiment (exemple&nbsp;: une cour)&nbsp;?"
 msgstr ""
 "Is there an exterior path between the sidewalk and the main entrance of the "
-"building (example: a yard)?"
+"facility (example: a yard)?"
 
 msgid "L'accès à l'entrée depuis la voirie se fait par un chemin extérieur"
 msgstr "Access to the entrance from the road is via an outside path"
@@ -1230,21 +1229,21 @@ msgstr ""
 " other non-stabilized surface)"
 
 msgid "Chemin extérieur de plain-pied"
-msgstr "Exterior walkway on one level"
+msgstr "Outside walkway on ground-level"
 
 msgid ""
 "Le chemin est-il de plain-pied, c'est-à-dire sans marche ni ressaut "
 "supérieur à 2 centimètres&nbsp;? Attention plain-pied ne signifie pas plat "
 "mais sans rupture brutale de niveau."
 msgstr ""
-"Is the path level, i.e. without any step or step greater than 2 centimeters?"
-" Be careful, level does not mean flat, but without a sudden break in level."
+"Is the path ground-level, i.e. without any step or step greater than 2 centimeters?"
+" Be careful, ground-level does not mean flat, but without a sudden break in level."
 
 msgid ""
 "L'accès à cet espace se fait de plain-pied, c'est à dire sans rupture "
 "brutale de niveau"
 msgstr ""
-"Access to this space is on the same level, i.e. without any sudden change in"
+"Access to this space is on the same ground-level, i.e. without any sudden change in"
 " level"
 
 msgid ""
@@ -1318,13 +1317,13 @@ msgstr "The staircase is not equipped with a handrail"
 msgid ""
 "S'il existe une rampe ayant une pente douce, est-elle fixe ou "
 "amovible&nbsp;?"
-msgstr "If there is a ramp with a gentle slope, is it fixed or removable?"
+msgstr "If there is a ramp with a gentle slope, is it stationary or removable?"
 
 msgid "Présence d'une rampe fixe ou amovible"
-msgstr "Presence of a fixed or removable ramp"
+msgstr "Presence of a stationary or removable ramp"
 
 msgid "Pas de rampe fixe ou amovible"
-msgstr "No fixed or removable ramps"
+msgstr "No stationary or removable ramps"
 
 msgid "Pente"
 msgstr "Slope"
@@ -1348,14 +1347,14 @@ msgid ""
 "Un dévers est une inclinaison transversale du chemin. S'il en existe un, "
 "quel est son degré de difficulté&nbsp;?"
 msgstr ""
-"A slope is a transverse inclination of the path. If there is one, what is "
+"A camber is a transverse inclination of the path. If there is one, what is "
 "its degree of difficulty?"
 
 msgid "Dévers ou inclinaison transversale du chemin"
-msgstr "Slope or cross slope of the road"
+msgstr "camber or cross slope of the road"
 
 msgid "Pas de dévers ou d'inclinaison transversale du chemin"
-msgstr "No slope or cross slope of the path"
+msgstr "No camber or cross slope of the path"
 
 msgid ""
 "Présence d'une bande de guidage au sol facilitant le déplacement d'une "
@@ -1368,17 +1367,17 @@ msgid ""
 "Pas de bande de guidage au sol facilitant le déplacement d'une personne "
 "aveugle ou malvoyante"
 msgstr ""
-"No guide strip on the floor to facilitate the movement of a blind or "
+"No guiding strip on the floor to facilitate the movement of a blind or "
 "visually impaired person"
 
 msgid "Rétrécissement du chemin"
-msgstr "Narrowing of the path"
+msgstr "Path narrowing"
 
 msgid ""
 "Existe-t-il un ou plusieurs rétrécissements (inférieur à 90 centimètres) du "
 "chemin emprunté par le public pour atteindre l'entrée&nbsp;?"
 msgstr ""
-"Is there a narrowing or narrowings (less than 90 centimeters) in the path "
+"Is there a narrowing or several narrowings (less than 90 centimeters) in the path "
 "used by the public to reach the entrance?"
 
 msgid ""
@@ -1392,7 +1391,7 @@ msgid ""
 "Pas de rétrécissement inférieur à 90 centimètres du chemin pour atteindre la"
 " zone d'accueil"
 msgstr ""
-"No narrowing of the path to the reception area by less than 90 centimeters"
+"No path narrowing to the reception area by less than 90 centimeters"
 
 msgid ""
 "Y a-t-il des éléments facilitant le repérage de l'entrée de l'établissement "
@@ -1404,31 +1403,30 @@ msgstr ""
 "architectural elements, etc.)?"
 
 msgid "L'entrée de l'établissement est facilement repérable"
-msgstr "The entrance to the facility is easily identifiable"
+msgstr "The facility entrance is easily identifiable"
 
 msgid ""
 "Pas d'éléments facilitant le repérage de l'entrée de l'établissement (numéro"
 " de rue à proximité, enseigne, végétaux, éléments architecturaux contrastés,"
 " etc)"
 msgstr ""
-"No elements that facilitate the identification of the entrance to the "
-"facility (street number nearby, sign, vegetation, contrasting "
+"No elements that facilitate the identification of the facility entrance (street number nearby, sign, vegetation, contrasting "
 "architectural elements, etc.)"
 
 msgid "Y a-t-il une porte ?"
 msgstr "Is there a door?"
 
 msgid "Y a-t-il une porte à l'entrée de l'établissement&nbsp;?"
-msgstr "Is there a door at the entrance of the facility?"
+msgstr "Is there a door at the facility entrance?"
 
 msgid "Présence d'une porte à l'entrée de l'établissement"
-msgstr "Presence of a door at the entrance of the facility"
+msgstr "Presence of a door at the facility entrance"
 
 msgid "Pas de porte à l'entrée de l'établissement"
-msgstr "No door at the entrance of the facility"
+msgstr "No door at the facility entrance"
 
 msgid "Manoeuvre de la porte"
-msgstr "Operating the door"
+msgstr "Door handling"
 
 msgid "Comment s'ouvre la porte&nbsp;?"
 msgstr "How does the door open?"
@@ -1449,32 +1447,32 @@ msgid "La porte d'entrée n'est pas vitrée"
 msgstr "The front door is not glazed"
 
 msgid "Repérage de la vitre"
-msgstr "Locating the glass"
+msgstr "Identification of the glass"
 
 msgid ""
 "Y a-t-il des éléments contrastés (autocollants, éléments de menuiserie ou "
 "autres) permettant de repérer la porte vitrée&nbsp;?"
 msgstr ""
 "Are there any contrasting elements (stickers, woodwork or other elements) to"
-" identify the glass door?"
+" identify the glazed door?"
 
 msgid ""
 "Des éléments contrastés permettent de visualiser les parties vitrées de "
 "l'entrée"
 msgstr ""
-"Contrasting elements make it possible to visualize the glass parts of the "
+"Contrasting elements make it possible to visualize the glazed parts of the "
 "entrance"
 
 msgid ""
 "Pas d'éléments contrastés permettant de visualiser les parties vitrées de "
 "l'entrée"
-msgstr "No contrasting elements to visualize the glass parts of the entrance"
+msgstr "No contrasting elements to visualize the glazed parts of the entrance"
 
 msgid ""
 "L'entrée est-elle de plain-pied, c'est-à-dire sans marche ni ressaut "
 "supérieur à 2 centimètres&nbsp;?"
 msgstr ""
-"Is the entrance level, i.e. without steps or a step greater than 2 "
+"Is the entrance ground-level, i.e. without steps or a step greater than 2 "
 "centimeters?"
 
 msgid ""
@@ -1486,7 +1484,7 @@ msgstr ""
 msgid ""
 "L'entrée n'est pas de plain-pied et présente une rupture brutale de niveau"
 msgstr ""
-"The entrance is not on the same level and presents a brutal break in level"
+"The entrance is not on the same ground-level and presents a brutal break in level"
 
 msgid "Présence d'un ascenseur ou d'un élévateur"
 msgstr "Presence of an elevator"
@@ -1495,7 +1493,7 @@ msgid "Pas de marches d'escalier"
 msgstr "No stairs"
 
 msgid "Repérage des marches"
-msgstr "Marking of the steps"
+msgstr "Identification of the steps"
 
 msgid "Dispositif d'appel à l'entrée"
 msgstr "Calling device at the entrance"
@@ -1522,27 +1520,27 @@ msgid "Dispositifs d'appels présents"
 msgstr "Calling devices present"
 
 msgid "Balise sonore à l'entrée"
-msgstr "Sound beacon at the entrance"
+msgstr "audio location signal at the entrance"
 
 msgid ""
 "L'entrée est-elle équipée d'une balise sonore facilitant son repérage par "
 "une personne aveugle ou malvoyante&nbsp;?"
 msgstr ""
-"Is the entrance equipped with an audible beacon to facilitate its location "
+"Is the entrance equipped with an audio location signal to facilitate its location "
 "by a blind or visually impaired person?"
 
 msgid ""
 "Présence d'une balise sonore facilitant son repérage par une personne "
 "aveugle ou malvoyante"
 msgstr ""
-"Presence of an audible beacon to facilitate its location by a blind or "
+"Presence of an audio location signal to facilitate its location by a blind or "
 "visually impaired person"
 
 msgid ""
 "Pas de balise sonore facilitant son repérage par une personne aveugle ou "
 "malvoyante"
 msgstr ""
-"No audible beacon to facilitate its location by a blind or visually impaired"
+"No audio location signal to facilitate its location by a blind or visually impaired"
 " person"
 
 msgid "Présence ou possibilité d'une aide humaine au déplacement"
@@ -1628,12 +1626,12 @@ msgid ""
 " mais sans rupture brutale de niveau)"
 msgstr ""
 "Once you have entered the building, is the path to the reception of the "
-"facility level, i.e. without any step or step greater than 2 "
+"facility ground-level, i.e. without any step or step greater than 2 "
 "centimeters? (attention, level does not mean flat, but without a sudden "
 "break in level)"
 
 msgid "Repérage des marches ou de l'escalier"
-msgstr "Locating the steps or staircase"
+msgstr "identification of the steps or staircase"
 
 msgid ""
 "Nez de marche contrastés, bande d'éveil à la vigilance en haut de l'escalier"
@@ -1997,7 +1995,7 @@ msgid "Pas de stationnement adapté à proximité"
 msgstr "No adapted parking nearby"
 
 msgid "Chemin d’accès de plain pied"
-msgstr "Level access road"
+msgstr "Ground level access road"
 
 #, python-format
 msgid "Chemin rendu accessible (%s)"
@@ -2013,7 +2011,7 @@ msgid "Difficulté sur le chemin d'accès"
 msgstr "Difficulty on the access road"
 
 msgid "Entrée de plain pied"
-msgstr "Ground level entrance"
+msgstr "Ground-level entrance"
 
 msgid "Entrée de plain pied mais étroite"
 msgstr "Single level but narrow entrance"
@@ -2047,7 +2045,7 @@ msgid "Personnel sensibilisé / formé"
 msgstr "Awared / trained staff"
 
 msgid "Balise sonore"
-msgstr "Sound beacon"
+msgstr "audio location device"
 
 msgid "Sanitaire adapté"
 msgstr "Adapted sanitary"
@@ -2302,7 +2300,7 @@ msgid "Le concours est terminé"
 msgstr "The challenge is over"
 
 msgid ""
-"Le concours a démarré, mais aucun participant n'a encore ajouté "
+"Le challenge a démarré, mais aucun participant n'a encore ajouté "
 "d'établissement."
 msgstr ""
 "The challenge has started, but no participant has added a facility yet."
@@ -2428,7 +2426,7 @@ msgid "Supprimer mon compte"
 msgstr "Delete my account"
 
 msgid "Souhaitez vous confirmer la suppression de votre compte ?"
-msgstr "Would you like to confirm the deletion of your account?"
+msgstr "Do you confirm the deletion of your account?"
 
 msgid ""
 "Toutes vos contributions sont conservées, en revanche, votre identifiant "


### PR DESCRIPTION
plusieurs suggestions: 
- faire un search & replace sur commune pour traduire toujours par “commune”
- faire un search & replace sur arrondissement pour traduire toujours par “district”
- faire un search & replace sur les sanitaires qu’on remplace par toilettes en français et en anglais
- faire un search & replace sur audio beacon et le remplacer par audio location device