### PR TITLE
Address can have a distinct format.

### DIFF
--- a/erp/views.py
+++ b/erp/views.py
@@ -736,8 +736,11 @@ def contrib_global_search(request):
 
     # remove postal code in where
     address = re.split(r"\(|\)", request.GET.get("where") or "()")
-    city = address[0].strip()
-    postal_code = address[1]
+    city = ""
+    postal_code = ""
+    if len(address) == 2:
+        city = address[0].strip()
+        postal_code = address[1]
 
     return render(
         request,


### PR DESCRIPTION
The previous code was working only when the search was a municipality: `Paris (75010)` but was not working for a street like: `11 rue le peletier 75009 Paris`. This is a hotfix and can be enhance later to parse the "where" even on inputs of kind street.

:warning: targetting production