### PR TITLE
Improve search inside of municipality

### DIFF
--- a/erp/views.py
+++ b/erp/views.py
@@ -220,19 +220,21 @@ def _filter_erp_by_location(queryset, **kwargs):
     search_type = kwargs.get("search_type")
     lat, lon = kwargs.get("lat"), kwargs.get("lon")
     location = _parse_location_or_404(lat, lon)
+    postcode = kwargs.get("postcode")
 
     if search_type == settings.IN_MUNICIPALITY_SEARCH_TYPE:
         return queryset.filter(commune=kwargs.get("municipality").nom)
 
     if search_type == settings.ADRESSE_DATA_GOUV_SEARCH_TYPE_CITY:
-        return queryset.annotate(city=Lower("commune")).filter(city=kwargs.get("municipality").lower())
+        return queryset.annotate(city=Lower("commune")).filter(
+            city=kwargs.get("municipality").lower(), code_postal=postcode
+        )
 
     if search_type in (settings.ADRESSE_DATA_GOUV_SEARCH_TYPE_HOUSENUMBER, "Autour de moi", translate("Autour de moi")):
         return queryset.nearest(location, max_radius_km=0.2)
 
     if search_type == settings.ADRESSE_DATA_GOUV_SEARCH_TYPE_STREET:
         street_name = kwargs.get("street_name")
-        postcode = kwargs.get("postcode")
         return queryset.filter(code_postal=postcode, voie__icontains=street_name)
     return queryset
 

--- a/tests/erp/test_search.py
+++ b/tests/erp/test_search.py
@@ -47,7 +47,33 @@ def test_search_by_municipality(data, client):
         published=True,
     )
     filters = {
-        "what": "Boulangerie",
+        "where": "Jacou (34830)",
+        "search_type": "municipality",
+        "postcode": 34830,
+        "municipality": "Jacou",
+    }
+    query_string = urlencode(filters)
+    response = client.get(f"{reverse('search')}?{query_string}")
+    assert response.status_code == 200
+    assert response.context["where"] == "Jacou (34830)"
+    assert len(response.context["pager"]) == 1
+    assert response.context["pager"][0].nom == "Aux bons croissants"
+
+
+def test_search_by_municipality_with_multiple_postcodes_for_municipality(data, client):
+    Erp.objects.create(
+        nom="Out of town",
+        commune="Lille",
+        code_postal=59000,
+        published=True,
+    )
+    Erp.objects.create(
+        nom="Other postcode",
+        commune="Jacou",
+        code_postal=34831,
+        published=True,
+    )
+    filters = {
         "where": "Jacou (34830)",
         "search_type": "municipality",
         "postcode": 34830,


### PR DESCRIPTION
Do not rely only on the name of the municipality but also filter on the postcode to avoid situation where one city has multiple postcodes (example : Paris)