### PR TITLE
Fix showcase of specific ERP on ERP details page

### DIFF
--- a/templates/common/map.html
+++ b/templates/common/map.html
@@ -8,7 +8,7 @@
      data-refresh-api-url="{% url "erp-list" %}"
      data-should-refresh="{{ dynamic_map|default:'False' }}"
      data-api-key="{{ map_api_key|default:'' }}"
-     data-erp-identifer="{{ erp.uuid }}">
+     data-erp-identifier="{{ erp.uuid }}">
     <script id="commune-data" type="application/json">
     {% if commune_json %}{{ commune_json | safe }}{% else %}null{% endif %}
     </script>


### PR DESCRIPTION
The typo was causing the ERP not to be highlighted / showcased. This was introduced in 1e8cd7b207cce373917d019262c9e8f15e3c931d