### PR TITLE
Improve performances of the sitemaps for ERPs

### DIFF
--- a/core/sitemaps.py
+++ b/core/sitemaps.py
@@ -40,7 +40,7 @@ class ErpSitemap(Sitemap):
     limit = 1000
 
     def items(self):
-        return Erp.objects.published()
+        return Erp.objects.published().select_related("activite")
 
     def lastmod(self, obj):
         return obj.updated_at

--- a/tests/core/test_sitemaps.py
+++ b/tests/core/test_sitemaps.py
@@ -1,0 +1,24 @@
+from django.urls import reverse
+
+from erp.models import Erp
+
+
+def test_sitemap_erp_scales_properly(data, client, django_assert_max_num_queries):
+    with django_assert_max_num_queries(4):
+        response = client.get(reverse("sitemap", kwargs={"section": "erps"}))
+        assert response.status_code == 200
+        assert response.content is not None
+
+    for i in range(20):
+        Erp.objects.create(
+            nom="Erp",
+            activite=data.erp.activite,
+            published=True,
+            commune="Jacou",
+            commune_ext=data.erp.commune_ext,
+        )
+
+    with django_assert_max_num_queries(4):
+        response = client.get(reverse("sitemap", kwargs={"section": "erps"}))
+        assert response.status_code == 200
+        assert response.content is not None


### PR DESCRIPTION
When looking at Sentry we can see that the sitemap for the ERPs is having an issue: mean loading time of 1.58s and p95 of 2.16s. When looking at this data you have to take into account that this view is using a cache, that means that some hits are served in ~5ms (which has a lot of impact on mean and p95).

Looking at the trace you can see that the main issue is the page making a lot of SQL queries (around 1000 per page if my understanding is correct - the real number can't be seen in Sentry for whatever reason).

The issue is that we need to get the `activite` of the `ERP` (or at least the slug) to create the URL of the ERP that is used in the sitemap.

The issue is fixed using a select_related, this could be improve if needed by loading only the fields that are needed using `.only()`.

Add a test to show that it is scaling properly. This test only work as is because the cache is disabled for all tests in the settings (`setting_test.py`).

Without the fix the same test was around 23 queries (after the ERPs are created).