### PR TITLE
Improve performances of multiple pages

### DIFF
--- a/erp/managers.py
+++ b/erp/managers.py
@@ -85,6 +85,9 @@ class ErpQuerySet(models.QuerySet):
             qs = qs.filter(clause)
         return qs
 
+    def with_activity(self):
+        return self.select_related("activite")
+
     def find_similar(self, nom, commune, voie=None, lieu_dit=None):
         # FIXME: might be deprecated as this is not compliant with the last definition of a duplicate.
         # Prefer `find_duplicate`

--- a/erp/serializers.py
+++ b/erp/serializers.py
@@ -21,8 +21,6 @@ class SpecialErpSerializer(geojson.Serializer):
                 self._current[field] = obj.get_absolute_url()
             elif field == "adresse":
                 self._current[field] = obj.adresse
-            elif field == "has_accessibilite":
-                self._current[field] = obj.has_accessibilite()
             else:
                 try:
                     if "__" in field:

--- a/erp/urls.py
+++ b/erp/urls.py
@@ -78,7 +78,7 @@ urlpatterns = [
     ),
     path(
         "recherche/<str:commune_slug>/",
-        cache_user_page(views.search_in_municipality),
+        views.search_in_municipality,
         name="search_commune",
     ),
     path(


### PR DESCRIPTION
This commit will reduce the loading time of multiple pages by reducing the number of databases calls made to gather the data.

This optimization is composed of two parts:
- Prefetching the activity (`activite`) when gathering ERPs for a list display. The activity is always needed at some point to display the proper icon and/or build the link to the details page (which relies on the activity slug)
- Removing the `has_accessibilite` field from the serializer. This field was introduced in 007ef5326877728ce6a47c4ba4f32720a81b8caa where you can see it was used to display a specific icon on the map (function `createIcon` in `app.js`). As of today I found no trace of this property being used in any HTML or Javascript. We now display the same icon for all ERPs.

Each of these improvements reduce the number of queries mades when handling multiple ERPs and transforming them into GeoJSON using the `make_geojson` function.

This is the case in 4 different places:
- In the search results page. A test was added to check for scaling, without this commit the same test would need around ~15 queries to display the results (some base queries + 1 query for the ERPs + 1 query per ERP for the activity + 1 query per ERP for the accesbility data).
- In the `search_in_municipality` pages. A test was also added in this case (same results). I removed the cache because it seems the page is now fast enough that we don't need one.
- In the ERP details pages when we show the nearest ERPS.
- In the `contrib_admin_infos` view - this case is probably quite rare.

This should improve the overall performance of the website by avoiding a lot of queries and reducing the latency for some pages.