### PR TITLE
Fix ERP mislocated when using enterprise API

### DIFF
--- a/erp/provider/entreprise.py
+++ b/erp/provider/entreprise.py
@@ -78,7 +78,7 @@ def process_response(json_value, terms, code_insee):
                     "commune": etablissement["siege"]["libelle_commune"],
                     "code_postal": etablissement["siege"]["code_postal"],
                     "lieu_dit": "",
-                    "coordonnees": etablissement["siege"]["coordonnees"],
+                    "coordonnees": [etablissement["siege"]["longitude"], etablissement["siege"]["latitude"]],
                     "siret": etablissement["siege"]["siret"],
                     "code_insee": code_insee,
                     **normalize_sirene_adresse(etablissement["siege"], code_insee),

--- a/tests/erp/provider/test_entreprise.py
+++ b/tests/erp/provider/test_entreprise.py
@@ -133,7 +133,7 @@ def test_search(mocker):
             "commune": "COISE",
             "code_postal": "69590",
             "lieu_dit": "",
-            "coordonnees": "45.611594,4.455569",
+            "coordonnees": ["4.455569", "45.611594"],
             "siret": "21690062100014",
             "code_insee": "69062",
             "numero": None,


### PR DESCRIPTION
We were naively returning coords from API result, whereas it does not follow the format we except.
It was resulting into locating ERP somewhere in Africa.