### PR TITLE
Add Javascript file for DSFR and fix markup

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -28,6 +28,7 @@ import * as bootstrap from 'bootstrap'
 // Sentry
 import * as Sentry from '@sentry/browser'
 import { Integrations } from '@sentry/tracing'
+import '@gouvfr/dsfr/dist/dsfr/dsfr.module.min.js'
 window.Sentry = Sentry
 window.SentryIntegrations = Integrations
 

--- a/templates/editorial/header.html
+++ b/templates/editorial/header.html
@@ -59,4 +59,12 @@
             </div>
         </div>
     </div>
+    <div class="fr-header__menu fr-modal"
+         id="modal-499"
+         aria-labelledby="button-500">
+        <div class="fr-container">
+            <button class="fr-btn--close fr-btn" aria-controls="modal-499" title="Fermer">Fermer</button>
+            <div class="fr-header__menu-links"></div>
+        </div>
+    </div>
 </header>

--- a/templates/editorial/header.html
+++ b/templates/editorial/header.html
@@ -59,11 +59,9 @@
             </div>
         </div>
     </div>
-    <div class="fr-header__menu fr-modal"
-         id="modal-499"
-         aria-labelledby="button-500">
+    <div class="fr-header__menu fr-modal">
         <div class="fr-container">
-            <button class="fr-btn--close fr-btn" aria-controls="modal-499" title="Fermer">Fermer</button>
+            <button class="fr-btn--close fr-btn" title="{% translate "Fermer" %}">{% translate "Fermer" %}</button>
             <div class="fr-header__menu-links"></div>
         </div>
     </div>


### PR DESCRIPTION
In the future we are going to start using the Js part of the French Design System (for tabs, tags, etc).
To do so we need to add the Javascript file to the index.js file. When doing so the DSFR will generate a JS error because our HTML markup for the header is not valid (at least not from the DSFR point of view).

This commit fixes the markup so that we don't have this error for now. This does not mean we have a fully fonctionnal menu / header from the DSFR point of view as this would mean more work and some changes in the behavior / UX of the menu.

The DSFR *needs* this specific markup to be there for the component to work.

https://github.com/GouvernementFR/dsfr/blob/main/src/component/header/script/header/header-links.js#L12