### PR TITLE
Optimize API Key verification

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -1,3 +1,4 @@
+import sentry_sdk
 from django.conf import settings
 from rest_framework import permissions
 from rest_framework_api_key.models import APIKey
@@ -9,9 +10,9 @@ class IsAllowedForAction(permissions.BasePermission):
     def has_permission(self, request, view):
         key = request.META["HTTP_AUTHORIZATION"].split()[1]
         try:
-            api_key = APIKey.objects.get_from_key(key)
+            with sentry_sdk.start_span(description="Check signature of API KEY"):
+                api_key = APIKey.objects.get_from_key(key)
         except APIKey.DoesNotExist:
-            # This case should not happen as this permission is intented to be used in combination with HasAPIKey
             return False
 
         if api_key.name == settings.INTERNAL_API_KEY_NAME and view.action not in ("default", "list"):

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -8,7 +8,11 @@ class IsAllowedForAction(permissions.BasePermission):
     message = "For internal uses only."
 
     def has_permission(self, request, view):
-        key = request.META["HTTP_AUTHORIZATION"].split()[1]
+        auth = request.META.get("HTTP_AUTHORIZATION")
+        if not auth:
+            return False
+
+        key = auth.split()[1]
         try:
             with sentry_sdk.start_span(description="Check signature of API KEY"):
                 api_key = APIKey.objects.get_from_key(key)

--- a/core/settings.py
+++ b/core/settings.py
@@ -148,7 +148,6 @@ REST_FRAMEWORK = {
         "user": "3/second",
     },
     "DEFAULT_PERMISSION_CLASSES": [
-        "rest_framework_api_key.permissions.HasAPIKey",
         "api.permissions.IsAllowedForAction",
     ],
     "DEFAULT_RENDERER_CLASSES": [


### PR DESCRIPTION
This commit optmize the time spent to verify an API key.

Using two classes in `DEFAULT_PERMISSION_CLASSES` was causing an increase in latency for all API views. This is due to the fact that both the `HasAPIKey` and `IsAllowedForAction` classes are checking for the existence of the key using `get_from_key` (this calls a `is_valid` method which is doing some criptographic verifications that are slow).

As the `IsAllowedForAction` class is already checking the key, we don't really need the `HasAPIKey` class.

This commit also add a custom span so that in the future we know what is happening in the traces (avoiding a big blank in sentry)