### PR TITLE
Fix issue when adding "what" to search on city page

### DIFF
--- a/erp/views.py
+++ b/erp/views.py
@@ -299,6 +299,8 @@ def search_in_municipality(request, commune_slug):
         "commune": municipality,
         "commune_json": municipality.toTemplateJson(),
         "geojson_list": make_geojson(pager),
+        "search_type": settings.ADRESSE_DATA_GOUV_SEARCH_TYPE_CITY,
+        "municipality": municipality.nom,
     }
     return render(request, "search/results.html", context=context)
 


### PR DESCRIPTION
Fix an issue that would happen when a user would go on a municipality page and then add a "what" term to the search without adding any new parameter.