### PR TITLE
Enhance sitemap perfs.

### DIFF
--- a/core/sitemaps.py
+++ b/core/sitemaps.py
@@ -32,6 +32,9 @@ class CommuneSitemap(Sitemap):
     def lastmod(self, obj):
         return obj.updated_at
 
+    def get_latest_lastmod(*args, **kwargs):
+        return Commune.objects.having_published_erps().first().updated_at
+
 
 class ErpSitemap(Sitemap):
     changefreq = "daily"
@@ -44,6 +47,9 @@ class ErpSitemap(Sitemap):
 
     def lastmod(self, obj):
         return obj.updated_at
+
+    def get_latest_lastmod(*args, **kwargs):
+        return Erp.objects.published().order_by("-updated_at").first().updated_at
 
 
 class StaticViewSitemap(Sitemap):


### PR DESCRIPTION
Explicitely tell how to get the latest element's update date.
Before this change, it was taking more than 30s to generate the sitemap.xml
After it takes ~ 500ms on localhost, without any cache.

Without this change, it was based on `def lastmod` and looping through all
elements to perform a `max()`. See the following block code coming from Django
sitemap:

```py
    def get_latest_lastmod(self):
        if not hasattr(self, "lastmod"):
            return None
        if callable(self.lastmod):
            try:
return max([self.lastmod(item) for item in self.items()],
default=None)
            except TypeError:
                return None
        else:
            return self.lastmod
```

I am not sure we should perform so heavy SQL requests for this need, but at
least it works as before.