### PR TITLE
Fix CSRF issue on homepage and remove cache

### DIFF
--- a/erp/urls.py
+++ b/erp/urls.py
@@ -13,14 +13,6 @@ handler404 = views.handler404
 handler500 = views.handler500
 
 
-def cache_app_page():
-    return cache_per_user(APP_CACHE_TTL)(views.App.as_view())
-
-
-def cache_user_page(view):
-    return cache_per_user(APP_CACHE_TTL)(view)
-
-
 def cache_editorial_page(template_name, context=None):
     return cache_per_user(EDITORIAL_CACHE_TTL)(
         views.EditorialView.as_view(template_name=template_name, extra_context=context)
@@ -33,7 +25,7 @@ urlpatterns = [
     ############################################################################
     path(
         "",
-        cache_user_page(views.home),
+        views.home,
         name="home",
     ),
     path(

--- a/erp/views.py
+++ b/erp/views.py
@@ -33,7 +33,7 @@ from erp.provider import acceslibre
 from erp.provider import search as provider_search
 from erp.provider.search import filter_erps_by_equipments, get_equipments
 from stats.models import Challenge
-from stats.queries import get_count_active_contributors
+from stats.queries import get_active_contributors
 from subscription.models import ErpSubscription
 
 HOURS = 60 * 60
@@ -82,8 +82,8 @@ def home(request):
         request,
         "index.html",
         context={
-            "erp_count": Erp.objects.published().count(),
-            "contributor_count": get_count_active_contributors(),
+            "erps": Erp.objects.published(),
+            "contributors": get_active_contributors(),
         },
     )
 

--- a/stats/queries.py
+++ b/stats/queries.py
@@ -65,9 +65,8 @@ def get_stats_territoires(sort="completude", max=50):
     )
 
 
-def get_count_active_contributors():
-    """Retourne le nombre de contributeurs ayant apporté, modifié au moins une info publiée"""
-    return get_user_model().objects.filter(erp__published=True).distinct().count()
+def get_active_contributors():
+    return get_user_model().objects.filter(erp__published=True).distinct()
 
 
 def get_top_contributors():

--- a/stats/views.py
+++ b/stats/views.py
@@ -17,7 +17,7 @@ def stats(request):
         context={
             "current_date": datetime.datetime.now(),
             "nb_published_erps": erp_qs.count(),
-            "nb_contributors": queries.get_count_active_contributors(),
+            "nb_contributors": queries.get_active_contributors().count(),
             "top_contributors": global_stat.top_contributors,
             "erp_counts_histogram": global_stat.erp_counts_histogram,
             "stats_territoires": global_stat.get_stats_territoires(sort=sort)[:10],

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,6 +2,7 @@
 {% load a4a %}
 {% load static humanize %}
 {% load i18n %}
+{% load cache %}
 {% block page_title %}
     acceslibre, la plateforme collaborative de l'accessibilité
 {% endblock page_title %}
@@ -36,28 +37,30 @@
             </div>
         </div>
     </div>
-    <div class="fr-container">
-        <div class="fr-grid-row fr-grid-row--gutters fr-ml-1w fr-mr-1w fr-mb-2v fr-mt-5v ">
-            <div class="fr-col-12 fr-col-sm-4" style="text-align: center">
-                <p class="fr-h1">{{ erp_count|intcomma }}</p>
-                <p class="fr-text--xl fr-text--heavy">
-                    {% translate "lieux<br> référencés" %}
-                </p>
-            </div>
-            <div class="fr-col-12 fr-col-sm-4" style="text-align: center">
-                <p class="fr-h1">{{ contributor_count|intcomma }}</p>
-                <p class="fr-text--xl fr-text--heavy">
-                    {% translate "contributrices<br> et contributeurs" %}
-                </p>
-            </div>
-            <div class="fr-col-12 fr-col-sm-4" style="text-align: center">
-                <p class="fr-h1">{% translate "12 millions" %}</p>
-                <p class="fr-text--xl fr-text--heavy">
-                    {% translate "de personnes<br> concernées" %}
-                </p>
+    {% cache 3600 homepage_statistics %}
+        <div class="fr-container">
+            <div class="fr-grid-row fr-grid-row--gutters fr-ml-1w fr-mr-1w fr-mb-2v fr-mt-5v ">
+                <div class="fr-col-12 fr-col-sm-4" style="text-align: center">
+                    <p class="fr-h1">{{ erps.count|intcomma }}</p>
+                    <p class="fr-text--xl fr-text--heavy">
+                        {% translate "lieux<br> référencés" %}
+                    </p>
+                </div>
+                <div class="fr-col-12 fr-col-sm-4" style="text-align: center">
+                    <p class="fr-h1">{{ contributors.count|intcomma }}</p>
+                    <p class="fr-text--xl fr-text--heavy">
+                        {% translate "contributrices<br> et contributeurs" %}
+                    </p>
+                </div>
+                <div class="fr-col-12 fr-col-sm-4" style="text-align: center">
+                    <p class="fr-h1">{% translate "12 millions" %}</p>
+                    <p class="fr-text--xl fr-text--heavy">
+                        {% translate "de personnes<br> concernées" %}
+                    </p>
+                </div>
             </div>
         </div>
-    </div>
+    {% endcache %}
     <div class="fr-grid-row bg-alt-blue-france-975">
         <div class="fr-container ">
             <div class="fr-grid-row fr-grid-row--gutters fr-mb-2v fr-mt-5v ">


### PR DESCRIPTION
Due to the cache that was added on the homepage route, the CSRF token for the language selection was outdated most of the time, leading to a CSRF error.

- Fix the CSRF error by removing the cache on the route
- Add cache on the only part of the template that was a bit long (displaying statistics, which needs some expensive DB queries)
- Rewrite the queries so that they can be kept lazy until the template block - it seems the .count() operation is never kept lazy when passed into the context. I passed queryset instead and moved the count operation in the template.