### PR TITLE
Reduce nb communes displayed per page.

### DIFF
--- a/core/sitemaps.py
+++ b/core/sitemaps.py
@@ -24,10 +24,10 @@ class CommuneSitemap(Sitemap):
     changefreq = "weekly"
     protocol = "https"
     priority = 0.6
-    limit = 10000
+    limit = 1000
 
     def items(self):
-        return Commune.objects.having_published_erps()
+        return Commune.objects.having_published_erps().only("slug")
 
     def lastmod(self, obj):
         return obj.updated_at


### PR DESCRIPTION
The longest part is the template rendering, 10000 objects was too much ! Use `only('slug')`, as the only thing we need is things in `def get_absolute_url`.