### PR TITLE
Fix JavaScript error when trackers are blocked

### DIFF
--- a/static/js/widget.js
+++ b/static/js/widget.js
@@ -26,7 +26,15 @@
   }
 
   function getTracker() {
-    return window.AccesLibreMatomoTracker
+    if (window.AccesLibreMatomoTracker) {
+      return window.AccesLibreMatomoTracker
+    } else {
+      // In case Matomo is not available (eg: Adblock) return a mock to avoid errors
+      // in the rest of the code
+      return {
+        trackEvent: function () {},
+      }
+    }
   }
 
   function openModal(dialog) {


### PR DESCRIPTION
Fix JavaSciprt error that could occur when Matomo is blocked (example: with Ublock Origin). This would led to some errors further down, just mock the only function we use in this case.

Fix ACCESLIBRE-19N
Fix ACCESLIBRE-19M
Fix ACCESLIBRE-19P
Fix ACCESLIBRE-19Q