### PR TITLE
Do not force submit button to be enabled.

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -69,19 +69,4 @@ window.onload = function () {
       dst.value = src.value.split('@')[0]
     })
   }
-
-  var loader = document.querySelector('.loader-api')
-  if (loader) {
-    loader.addEventListener('click', function (e) {
-      wait_screen()
-    })
-    loader.addEventListener('submit', function () {
-      wait_screen()
-    })
-  }
-
-  function wait_screen() {
-    document.querySelector('#content').classList.add('blur')
-    document.querySelector('#spinner_container').style.display = 'block'
-  }
 }

--- a/static/js/ui/SearchWhere.js
+++ b/static/js/ui/SearchWhere.js
@@ -25,14 +25,14 @@ function SearchWhere(root) {
     street_name: root.querySelector('input[name=street_name]'),
     municipality: root.querySelector('input[name=municipality]'),
   }
-  input.addEventListener('input', activate_submit_btn, false)
-  activate_submit_btn((event = false), (force = false))
+  input.addEventListener('input', activateSubmitBtn, false)
+  activateSubmitBtn((event = false), (force = false))
 
-  function activate_submit_btn(event, force = false) {
+  function activateSubmitBtn(event, force = false) {
     if (hiddens.code.value.length == 0) {
       input.form.querySelector('button[type=submit]').setAttribute('disabled', '')
     }
-    if (force || hiddens.code.value) {
+    if (force || hiddens.code.value.length != 0) {
       input.form.querySelector('button[type=submit]').removeAttribute('disabled')
     }
   }
@@ -65,6 +65,7 @@ function SearchWhere(root) {
 
   const autocomplete = new Autocomplete(root, {
     debounceTime: 100,
+    submitOnEnter: true, // see https://github.com/trevoreyre/autocomplete/issues/157
 
     getResultValue: ({ text }) => text,
 
@@ -72,7 +73,6 @@ function SearchWhere(root) {
       if (!result) {
         return
       }
-      activate_submit_btn((event = false), (force = true))
       if (result.lat && result.lon) {
         setSearchData(result)
       } else if (result.text.startsWith(AROUND_ME)) {
@@ -96,6 +96,7 @@ function SearchWhere(root) {
       } else {
         setSearchData(null)
       }
+      activateSubmitBtn((event = false), (force = true))
     },
 
     renderResult: ({ text, context, icon }, props) => {
@@ -143,7 +144,7 @@ function SearchWhere(root) {
       try {
         submittable = exp.target.getAttribute('aria-expanded') !== 'true'
         if (submittable) {
-          activate_submit_btn(null, (force = true))
+          activateSubmitBtn(null, (force = false))
         }
       } catch (e) {}
     }, 0)

--- a/templates/contrib/forms/search.html
+++ b/templates/contrib/forms/search.html
@@ -86,7 +86,7 @@
             </div>
             <button type="submit"
                     {% if 'contrib' in request.path %}disabled{% endif %}
-                    class="fr-col-2 fr-col-sm-1 fr-text--sm fr-btn btn-search{% if 'contrib' in request.path %} loader-api{% endif %}"
+                    class="fr-col-2 fr-col-sm-1 fr-text--sm fr-btn btn-search"
                     title="{% translate "Rechercher" %}">
                 <span class="sr-only">{% translate "Rechercher" %}</span>
             </button>

--- a/templates/search/form.html
+++ b/templates/search/form.html
@@ -65,7 +65,7 @@
             </div>
             <button type="submit"
                     {% if 'contrib' in request.path %}disabled{% endif %}
-                    class="fr-col-2 fr-col-sm-1 fr-text--sm fr-btn btn-search{% if 'contrib' in request.path %} loader-api{% endif %}"
+                    class="fr-col-2 fr-col-sm-1 fr-text--sm fr-btn btn-search"
                     title="{% translate "Rechercher" %}">
                 <span class="sr-only">{% translate "Rechercher" %}</span>
             </button>


### PR DESCRIPTION
Let the `activateSubmitBtn` function responsible for checking if the button should be enabled or not.
If provided address is not valid, `code` will remain empty and so, we should not force the button to be enabled.

Remove spinner. Seems useless, if it need to be bring back, it should be done in a better manner.

Move the `activateSubmitBtn` in onSubmit, so that if search data is emptied it will not activate the button.

The 2 scenarios to test :
- an invalid address should not activate the button
- choosing an entry with the keyboard (enter key) should activate the button