### PR TITLE
Auto add filters and shortcuts in URL.

### DIFF
--- a/static/js/geo.js
+++ b/static/js/geo.js
@@ -379,9 +379,19 @@ function broadenSearchOnClick(broaderSearchButton, map, root) {
   })
 }
 
+function refreshURL() {
+  let queryParams = new URLSearchParams(window.location.search)
+  ;['equipments', 'equipments_shortcuts'].forEach(function (inputName) {
+    let inputs = document.querySelectorAll(`input[name=${inputName}]:checked`)
+    inputs.forEach((input) => queryParams.append(inputName, input.value))
+  })
+  history.replaceState(null, null, '?' + queryParams.toString())
+}
+
 function refreshMapOnEquipmentsChange(equipmentsInputs, map, root) {
   document.addEventListener('filterChanged', async function () {
     refreshData(map, root.dataset.refreshApiUrl, root.dataset.apiKey)
+    refreshURL()
   })
 }
 


### PR DESCRIPTION
In order to be able to retrieve our search when performing a "previous page" action, automaticcaly add filters and shortcuts in request.GET.