### PR TITLE
Contact form was not submittable if authenticated

### DIFF
--- a/templates/contact_form/contact_form.html
+++ b/templates/contact_form/contact_form.html
@@ -81,7 +81,7 @@
             {{ form.body|as_crispy_field }}
             {{ form.user|as_crispy_field }}
             {{ form.next|as_crispy_field }}
-            {% if not user.is_authenticated %}{{ form.robot|as_crispy_field }}{% endif %}
+            {{ form.robot|as_crispy_field }}
             <div class="form-group">
                 <button type="submit" class="btn btn-primary btn-block">{% translate "Envoyer" %}</button>
             </div>


### PR DESCRIPTION
robot is required in the form, so it can't be hidden for authenticated users otherwise it raises a form.error.
This could be enhance if we really don't want to have authenticated users to check this box. But at least it mitigates the pb.