### PR TITLE
Fix autocomplete display on small screens

### DIFF
--- a/static/scss/style.scss
+++ b/static/scss/style.scss
@@ -154,7 +154,7 @@ select[name='language'] {
 }
 
 .autocomplete-result-list {
-  z-index: 2 !important;
+  z-index: 501 !important;
 }
 
 .a4a {


### PR DESCRIPTION
On small screens (vertical height under 950px but with a "large" / non mobile display) the autocomplete of the "where" field would go under the header, making it impossible to click on the first n elements.

Change z-index of the autocomplete in order to fix this.