### PR TITLE
Get other_activity in edit mode.

### DIFF
--- a/erp/views.py
+++ b/erp/views.py
@@ -936,7 +936,7 @@ def contrib_edit_infos(request, erp_slug):
             "libelle_step": {"current": "informations", "next": libelle_next},
             "erp": erp,
             "form": form,
-            "activite": Activite.objects.get(slug="autre"),
+            "other_activity": Activite.objects.only("id").get(slug="autre"),
             # Zoom in/out is not permitted in edit mode as it would result into a position change of the cross
             "map_options": json.dumps({"scrollWheelZoom": False}),
         },


### PR DESCRIPTION
The dict key to render the template had been renamed into https://github.com/MTES-MCT/acceslibre/commit/8ef316d9eb3c35e3f6f1637d7ab9dac72a7ceef0 but this change had not been reflected in the edit part. Get only the ID, we have no need of other attributes.