### PR TITLE
Fix issue with widget tracking when URL is long (#865)

### DIFF
--- a/stats/middleware.py
+++ b/stats/middleware.py
@@ -21,6 +21,7 @@ class TrackStatsWidget:
 
     def _update_event(self, request):
         referer = request.headers.get("X-OriginUrl")
+        referer = referer[:199]
         domain = urlparse(referer).netloc or referer
         date = datetime.date.today()
 

--- a/tests/stats/tests.py
+++ b/tests/stats/tests.py
@@ -24,6 +24,22 @@ def test_widget_tracking(data):
 
 
 @pytest.mark.django_db
+def test_widget_tracking_with_long_url(data):
+    c = Client()
+    headers = {
+        "HTTP_X-Originurl": "http://test_widget_external_website.tld/?utm=" + 200 * "#",
+    }
+    assert WidgetEvent.objects.all().count() == 0
+    response = c.get(reverse("widget_erp_uuid", kwargs={"uuid": data.erp.uuid}), **headers)
+    assert response.status_code == 200
+
+    event = WidgetEvent.objects.get()
+    assert event.views == 1
+    assert event.domain == "test_widget_external_website.tld"
+    assert event.referer_url.startswith("http://test_widget_external_website.tld/?utm=")
+
+
+@pytest.mark.django_db
 def test_widget_tracking_multiple_views(data):
     c = Client()
     headers = {


### PR DESCRIPTION
Fix an issue with widget tracking when the referer URL is > 200 characters.

Fix ACCESLIBRE-1C8