### PR TITLE
Relay activity to the contrib admin info page

### DIFF
--- a/erp/views.py
+++ b/erp/views.py
@@ -811,6 +811,7 @@ def contrib_global_search(request):
                 "commune": city,
                 "lat": request.GET.get("lat"),
                 "lon": request.GET.get("lon"),
+                "activite": activite.pk if activite else None,
                 "activite_slug": activite.slug if activite else None,
                 "new_activity": request.GET.get("new_activity"),
                 "code_postal": request.GET.get("postcode"),

--- a/tests/erp/test_contrib.py
+++ b/tests/erp/test_contrib.py
@@ -146,6 +146,9 @@ def test_contrib_start_global_search_with_existing(client, data, mocker, akei_re
     assert "exists" in response.context["results_bdd"][0]
     assert response.context["results_bdd"][0]["source"] == "acceslibre"
     assert response.context["results_bdd"][0]["id"] == obj_erp.id
+    assert all(
+        [x in response.context["query"] for x in ("nom", "commune", "activite", "code_postal", "lat", "lon")]
+    ), "Missing info for encode_provider_data"
 
 
 def test_claim(client, user, data):


### PR DESCRIPTION
This field will be b64encode on template side with `encode_provider_data` and then decoded in contrib admin infos views.
This will allow to prepopulate the activity field.