### PR TITLE
Ignore shift and control on autocomplete, add a required on what.

### DIFF
--- a/static/js/ui/SearchWhere.js
+++ b/static/js/ui/SearchWhere.js
@@ -128,7 +128,8 @@ function SearchWhere(root) {
   // Invalidate lat/lon on every key stroke in the search input, except when user tabs
   // out of the field or selects and entry by pressing the Enter key.
   autocomplete.input.addEventListener('keydown', (event) => {
-    if (event.key != 'Tab' && event.key != 'Enter') {
+    var ignoredKeys = ['Tab', 'Enter', 'Shift', 'Control']
+    if (!ignoredKeys.includes(event.key)) {
       setSearchData(null)
     }
   })

--- a/templates/contrib/forms/search.html
+++ b/templates/contrib/forms/search.html
@@ -20,6 +20,7 @@
                        placeholder="Le Louvre, Café de la gare..."
                        aria-label='{% translate "Rechercher un établissement, une activité. Exemple : Le Louvre, Café de la gare" %}'
                        autocomplete="off"
+                       required
                        {% if "what" in request.GET %} value="{{ what|default:request.GET.what }}" {% else %} value="{{ what }}" {% endif %}>
                 <div>
                     {% if form.errors.what %}


### PR DESCRIPTION
- Ignore shift and control, those keys should not empty the search values, i.e. if you perform a shift tab to go to the activity field, it should not wipe the where autocomplete
- add a required on the what field, so that it acts as the activity field, with a direct message if empty.