### PR TITLE
Fix our demo widget with multi tracker.

### DIFF
--- a/static/js/widget.js
+++ b/static/js/widget.js
@@ -40,9 +40,11 @@
     } else {
       // In case Matomo is not available (eg: Adblock) return a mock to avoid errors
       // in the rest of the code
-      return {
-        trackEvent: function () {},
-      }
+      return [
+        {
+          trackEvent: function () {},
+        },
+      ]
     }
   }
 


### PR DESCRIPTION
getTrackers is now returning an array of trackers. If we want to mock it we have to return a list of fake trackers.