### PR TITLE
Allow API to show un-published ERPs

### DIFF
--- a/api/filters.py
+++ b/api/filters.py
@@ -33,6 +33,12 @@ class ErpFilter(BaseFilterBackend):
     # FIXME: do NOT apply filters on details view
     def filter_queryset(self, request, queryset, view):
         use_distinct = False
+
+        # Drafts
+        with_drafts = request.query_params.get("with_drafts", False)
+        if not with_drafts:
+            queryset = queryset.published()
+
         # Commune (legacy)
         commune = request.query_params.get("commune", None)
         if commune is not None:

--- a/api/views.py
+++ b/api/views.py
@@ -377,7 +377,7 @@ class ErpSchema(A4aAutoSchema):
                 "name": "asp_id_not_null",
                 "in": "query",
                 "required": False,
-                "description": "ID ASP fournit",
+                "description": "Une valeur vraie ne renvoit que les établissement dont l'ID ASP est fournit",
                 "schema": {"type": "boolean"},
             },
         },
@@ -410,7 +410,7 @@ class ErpSchema(A4aAutoSchema):
                 "name": "clean",
                 "in": "query",
                 "required": False,
-                "description": "Écarter les valeurs nulles ou non-renseignées",
+                "description": "Une valeur vraie écarte les valeurs d'accessibilité nulles ou non-renseignées",
                 "schema": {"type": "boolean"},
             },
         },
@@ -421,7 +421,18 @@ class ErpSchema(A4aAutoSchema):
                 "name": "readable",
                 "in": "query",
                 "required": False,
-                "description": "Formater les données d'accessibilité pour une lecture humaine",
+                "description": "Une valeur vraie formate les données d'accessibilité pour une lecture humaine",
+                "schema": {"type": "boolean"},
+            },
+        },
+        "with_drafts": {
+            "paths": ["/erps/"],
+            "methods": ["GET"],
+            "field": {
+                "name": "with_drafts",
+                "in": "query",
+                "required": False,
+                "description": "Une valeur vraie permet de voir les établissements en brouillon (non publiés)",
                 "schema": {"type": "boolean"},
             },
         },
@@ -476,7 +487,7 @@ class ErpViewSet(
         "partial_update": ErpImportSerializer,
     }
 
-    queryset = Erp.objects.select_related("activite", "accessibilite").published().order_by("nom")
+    queryset = Erp.objects.select_related("activite", "accessibilite").order_by("nom")
     lookup_field = "slug"
     bbox_filter_field = "geom"
     filter_backends = (ZoneFilter, EquipmentFilter, ErpFilter)

--- a/tests/api/tests.py
+++ b/tests/api/tests.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 from rest_framework.test import APIClient
 
 from erp.models import Erp
+from tests.factories import ErpFactory
 
 
 @pytest.fixture
@@ -146,6 +147,19 @@ class TestErpApi:
             headers={"Accept": "application/geo+json"},
         )
         assert response.json() == geojson_expected_for_no_results
+
+    def test_list_can_show_drafts(self, api_client, data):
+        ErpFactory(published=False)
+
+        response = api_client.get(reverse("erp-list"))
+        assert response.status_code == 200
+        content = json.loads(response.content)
+        assert len(content["results"]) == 1
+
+        response = api_client.get(reverse("erp-list") + "?with_drafts=True")
+        assert response.status_code == 200
+        content = json.loads(response.content)
+        assert len(content["results"]) == 2
 
     def test_list_page_size(self, api_client, data):
         response = api_client.get(reverse("erp-list") + "?page_size=25")


### PR DESCRIPTION
Allow the users using the API to list un-published (drafts) ERPs using a query parameter / filter. Add test.