### PR TITLE
Bring back geojson_list for JS.

### DIFF
--- a/erp/views.py
+++ b/erp/views.py
@@ -292,6 +292,7 @@ def search(request):
         "equipments_shortcuts": get_equipments_shortcuts() if equipment_filters_feature else [],
         "equipments": get_equipments() if equipment_filters_feature else [],
         "zoom_level": zoom_level,
+        "geojson_list": make_geojson(pager),
     }
     return render(request, "search/results.html", context=context)
 

--- a/tests/erp/test_search.py
+++ b/tests/erp/test_search.py
@@ -39,6 +39,7 @@ def test_search_pagination(data, client):
     response = client.get(reverse("search") + "?where=jacou&code=34120&page=3")
     assert response.status_code == 200
     assert len(response.context["pager"]) == 1
+    assert "geojson_list" in response.context, "Missing info for map"
 
 
 def test_search_pagination_performances(data, client, django_assert_max_num_queries):


### PR DESCRIPTION
`geojson_list` disappeared, as direct consequence, the infinite scroll was not working anymore.