### PR TITLE
Use trgm_similarity on search.

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -29,6 +29,7 @@ class UserFactory(factory.django.DjangoModelFactory):
 
 class ActiviteFactory(factory.django.DjangoModelFactory):
     nom = factory.LazyAttribute(lambda x: faker.name())
+    mots_cles = factory.List([])
 
     class Meta:
         model = "erp.Activite"


### PR DESCRIPTION
Remove unused Commune.search function.
Use trgm similarity on search to have a higher weight on exact matches. Ex: searching for cultura should first return ERP with name Cultura and then ERP with name containing Culture.