### PR TITLE
Split matomo widget & website.

### DIFF
--- a/static/js/widget.js
+++ b/static/js/widget.js
@@ -169,7 +169,7 @@
   }
 
   function setupAnalytics() {
-    var matomoTracker = Matomo.getTracker('https://stats.data.gouv.fr/matomo.php', 118)
+    var matomoTracker = Matomo.getTracker('https://stats.beta.gouv.fr/matomo.php', 3)
     var matomoSecondaryTracker = Matomo.getTracker('https://acceslibre.matomo.cloud/matomo.php', 1)
     window.AccesLibreMatomoTracker = [matomoTracker, matomoSecondaryTracker]
     window.AccesLibreMatomoTracker.forEach(function (tracker) {
@@ -179,7 +179,7 @@
     })
   }
   function setupAnalyticsScript() {
-    var u = 'https://stats.data.gouv.fr/'
+    var u = 'https://stats.beta.gouv.fr/'
     ;(function () {
       var d = document,
         g = d.createElement('script'),

--- a/templates/common/matomo.html
+++ b/templates/common/matomo.html
@@ -10,10 +10,6 @@
     _paq.push(['setTrackerUrl', u + 'matomo.php']);
     _paq.push(['setSiteId', '118']);
 
-    var secondaryTracker = 'https://acceslibre.matomo.cloud/matomo.php';
-    var secondaryWebsiteId = '1';
-    _paq.push(['addTracker', secondaryTracker, secondaryWebsiteId]);
-
     var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
     g.async = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
   })();
@@ -33,6 +29,5 @@
 </script>
 <noscript>
     <img src="//stats.data.gouv.fr/matomo.php?idsite=118&amp;rec=1" alt="">
-    <img src="//acceslibre.matomo.cloud/matomo.php?idsite=1&amp;rec=1" alt="">
 </noscript>
 <!-- End Matomo Code -->


### PR DESCRIPTION
The primary tracker on widget side becomes stats.beta, the secondary is matomo.cloud.
On website, we now only use stats.data.