### PR TITLE
Do not set an approximative CommuneExt in imports.

### DIFF
--- a/erp/imports/mapper/gendarmerie.py
+++ b/erp/imports/mapper/gendarmerie.py
@@ -5,13 +5,13 @@ from datetime import datetime
 from django.contrib.gis.geos import Point
 from django.contrib.gis.measure import Distance
 
-from erp.models import Accessibilite, Commune, Erp
-from erp.provider import arrondissements
+from erp.imports.mapper.generic import GenericMapper
+from erp.models import Accessibilite, Erp
 
 logger = logging.getLogger(__name__)
 
 
-class GendarmerieMapper:
+class GendarmerieMapper(GenericMapper):
     erp = None
     fields = [
         "identifiant_public_unite",
@@ -53,7 +53,7 @@ class GendarmerieMapper:
         for name, value in basic_fields.items():
             setattr(self.erp, name, value)
 
-        self._retrieve_commune_ext()
+        self._retrieve_commune_ext(self.record.get("commune"))
         self._populate_accessibilite(self.record)
 
         return self.erp, None
@@ -126,28 +126,6 @@ class GendarmerieMapper:
             }
         except KeyError as key:
             raise RuntimeError(f"Impossible d'extraire des données: champ {key} manquant")
-
-    def _retrieve_commune_ext(self):
-        "Assigne une commune normalisée à l'Erp en cours de génération"
-        if self.erp.code_insee:
-            commune_ext = Commune.objects.filter(code_insee=self.erp.code_insee).first()
-            if not commune_ext:
-                arrdt = arrondissements.get_by_code_insee(self.erp.code_insee)
-                if arrdt:
-                    commune_ext = Commune.objects.filter(nom__iexact=arrdt["commune"]).first()
-        elif self.erp.code_postal:
-            commune_ext = Commune.objects.filter(code_postaux__contains=[self.erp.code_postal]).first()
-        else:
-            raise RuntimeError(f"Champ code_insee et code_postal nuls (commune: {self.erp.commune})")
-
-        if not commune_ext:
-            raise RuntimeError(
-                f"Impossible de résoudre la commune depuis le code INSEE ({self.erp.code_insee}) "
-                f"ou le code postal ({self.erp.code_postal}) "
-            )
-
-        self.erp.commune_ext = commune_ext
-        self.erp.commune = commune_ext.nom
 
     def _populate_accessibilite(self, record):
         if not self.erp.has_accessibilite():

--- a/tests/erp/imports/mapper/test_gendarmerie.py
+++ b/tests/erp/imports/mapper/test_gendarmerie.py
@@ -31,19 +31,19 @@ def test_updated_data(mapper, gendarmeries_valid):
     sample = gendarmeries_valid[0].copy()
     sample["code_commune_insee"] = "01283"
 
-    erp, reason = mapper(sample).process()
+    erp, _ = mapper(sample).process()
 
     assert erp.code_insee == "01283"
 
 
 def test_invalid_data(mapper, gendarmeries_valid):
     sample = gendarmeries_valid[0].copy()
-    sample["code_commune_insee"] = "67000azdasqd"
+    sample["code_commune_insee"] = sample["code_postal"] = "67000azdasqd"
 
     with pytest.raises(RuntimeError) as err:
         mapper(sample).process()
 
-    assert "résoudre la commune depuis le code INSEE" in str(err.value)
+    assert "Impossible de résoudre la commune depuis le code INSEE" in str(err.value)
 
 
 def test_fail_on_key_change(mapper, gendarmeries_valid):
@@ -59,7 +59,7 @@ def test_fail_on_key_change(mapper, gendarmeries_valid):
 
 def test_horaires(mapper, gendarmeries_valid):
     sample = gendarmeries_valid[0].copy()
-    erp, reason = mapper(sample).process()
+    erp, _ = mapper(sample).process()
 
     assert "Horaires d'accueil" in erp.accessibilite.commentaire
     assert "Lundi : 8h00-12h00 14h00-18h00" in erp.accessibilite.commentaire
@@ -67,7 +67,7 @@ def test_horaires(mapper, gendarmeries_valid):
 
 def test_horaires_missing(mapper, gendarmeries_valid):
     sample = gendarmeries_valid[2].copy()
-    erp, reason = mapper(sample).process()
+    erp, _ = mapper(sample).process()
 
     assert "Horaires d'accueil" not in erp.accessibilite.commentaire
 


### PR DESCRIPTION
Remove all occurences of `commune_ext =
Commune.objects.filter(code_postaux__contains=[self.erp.code_postal]).first()` This line is not correct and does not work for cities having the same postal code, it takes the first one without checking if it matches the city passed in the record.
Put all logic to retrieve commune_ext into a base function, change all mapper to inherit from the base one.


TODO 
- [x] add city name when calling the super()._retrieve_commune_ext on all mappers.