### PR TITLE
Add a merge operator for ERP

### DIFF
--- a/erp/exceptions.py
+++ b/erp/exceptions.py
@@ -1,0 +1,2 @@
+class MergeException(Exception):
+    pass


### PR DESCRIPTION
This will merge only the accessibility data and not the ERP itself. The method is added on the ERP model to ease the use.