### PR TITLE
Fix BAN not returning postal_code for TOM

### DIFF
--- a/erp/forms.py
+++ b/erp/forms.py
@@ -276,6 +276,13 @@ class BaseErpForm(forms.ModelForm):
         if not locdata or locdata.get("geom") is None:
             self.raise_validation_error("voie", f"Adresse non localisable : {adresse} ({code_postal})")
 
+        # NOTE: ATM there is a bug on api-adresse, it does not return postal_code for TOM
+        # ex https://api-adresse.data.gouv.fr/search/?q=41+Avenue+FOCH%2C+NOUMEA&limit=1
+        # Once solved on their side, remove the following if block
+        if code_postal and not locdata["code_postal"] and locdata["code_insee"]:
+            if code_postal[:2] == locdata["code_insee"][:2]:
+                locdata["code_postal"] = code_postal
+
         # Ensure picking the right postcode
         if code_postal and locdata["code_postal"] and code_postal != locdata["code_postal"]:
             dpt_result = locdata["code_postal"][:2]

--- a/erp/provider/departements.py
+++ b/erp/provider/departements.py
@@ -410,9 +410,17 @@ DEPARTEMENTS = {
         "nom": "Mayotte",
         "region": "Mayotte",
     },
+    "977": {
+        "nom": "Saint-Barthélemy",
+        "region": "Saint-Barthélemy",
+    },
     "978": {
         "nom": "Saint-Martin",
         "region": "Saint-Martin",
+    },
+    "984": {
+        "nom": "Terres australes et antarctiques françaises",
+        "region": "Terres australes et antarctiques françaises",
     },
     "986": {
         "nom": "Wallis et Futuna",
@@ -425,6 +433,10 @@ DEPARTEMENTS = {
     "988": {
         "nom": "Nouvelle-Calédonie",
         "region": "Nouvelle-Calédonie",
+    },
+    "989": {
+        "nom": "La Passion-Clipperton",
+        "region": "La Passion-Clipperton",
     },
 }
 

--- a/tests/erp/provider/test_departements.py
+++ b/tests/erp/provider/test_departements.py
@@ -42,5 +42,5 @@ def test_search_departement_exclude_stopword():
 
 
 def test_search_departement_limit():
-    assert len(departements.search("er")) == 10
+    assert len(departements.search("er")) == 12
     assert len(departements.search("er", limit=5)) == 5


### PR DESCRIPTION
ATM there is a bug on api-adresse, it does not return postal_code for TOM ex https://api-adresse.data.gouv.fr/search/?q=41+Avenue+FOCH%2C+NOUMEA&limit=1 So if we have a filled in code_postal and no postal_code from la BAN but a insee code, consider the filled in code_postal as valid :finger_crossed: