### PR TITLE
Reboot Celery workers once in a while

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -2,4 +2,4 @@ web: gunicorn --chdir core core.wsgi --log-file -
 
 postdeploy: bash bin/post_deploy
 
-worker: celery -A core worker -l info
+worker: celery -A core worker -l info --max-tasks-per-child=500


### PR DESCRIPTION
Celery will end up using some swap add taking more memory than needed. Start with 500 and we will monitor it.

https://docs.celeryq.dev/en/latest/userguide/workers.html#max-tasks-per-child-setting