### PR TITLE
Adapt command to remove duplicates for town halls

### DIFF
--- a/erp/exceptions.py
+++ b/erp/exceptions.py
@@ -1,2 +1,6 @@
 class MergeException(Exception):
     pass
+
+
+class MultipleAspIdForDuplicates(Exception):
+    pass


### PR DESCRIPTION
This change will lead to the number of "unhandled" cases to be falsy in dry mode because all the ERPs will be counted (see test).

As we are no longer sure that we keep the ERP coming from service public we need to copy the ASP Id when it exists.