### PR TITLE
Add command to update geometry of Commune

### DIFF
--- a/erp/management/commands/update_geometry.py
+++ b/erp/management/commands/update_geometry.py
@@ -1,0 +1,41 @@
+import requests
+from django.contrib.gis.geos import Point
+from django.core.management.base import BaseCommand
+from requests.exceptions import JSONDecodeError
+
+from core.lib import geo
+from erp.models import Commune
+
+
+class Command(BaseCommand):
+    help = "Update all contours and centers objects based on official API"
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            "--write",
+            action="store_true",
+            help="Actually edit the database",
+        )
+
+    def handle(self, *args, **options):
+        queryset = Commune.objects.filter(arrondissement=False, obsolete=False)
+
+        for commune in queryset:
+            insee_code = commune.code_insee
+            response = requests.get(f"https://geo.api.gouv.fr/communes/{insee_code}?fields=contour,centre")
+
+            try:
+                json_data = response.json()
+            except JSONDecodeError:
+                print(f"Can't update {insee_code}, reponse : {response}")
+                continue
+
+            commune.contour = geo.geojson_mpoly(json_data["contour"])
+            commune.geom = Point(
+                json_data["centre"]["coordinates"][0],
+                json_data["centre"]["coordinates"][1],
+                srid=4326,
+            )
+
+            if options["write"]:
+                commune.save()

--- a/tests/erp/test_command_update_geometry.py
+++ b/tests/erp/test_command_update_geometry.py
@@ -1,0 +1,56 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.management import call_command
+
+from erp.models import Commune
+from tests.factories import CommuneFactory, ErpFactory
+
+DETAILS_JSON = {
+    "centre": {"type": "Point", "coordinates": [2.1191, 48.8039]},
+    "contour": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [4.956045, 46.153859],
+                [4.957825, 46.153507],
+                [4.958097, 46.153422],
+                [4.958412, 46.153273],
+                [4.956045, 46.153859],
+            ]
+        ],
+    },
+}
+
+
+@pytest.mark.django_db
+@patch("erp.management.commands.update_geometry.requests.get")
+def test_command_will_update_geom(mocked_api):
+    commune = CommuneFactory(code_insee="01001")
+    assert commune.contour is None
+    mocked_api.return_value.json.return_value = DETAILS_JSON
+
+    call_command("update_geometry", write=True)
+    mocked_api.assert_called_once_with("https://geo.api.gouv.fr/communes/01001?fields=contour,centre")
+
+    commune = Commune.objects.get()
+    assert commune.geom.coords == (2.1191, 48.8039)
+    assert commune.contour.coords[0] == (
+        (
+            (4.956045, 46.153859),
+            (4.957825, 46.153507),
+            (4.958097, 46.153422),
+            (4.958412, 46.153273),
+            (4.956045, 46.153859),
+        ),
+    )
+
+
+@pytest.mark.django_db
+@patch("erp.management.commands.update_geometry.requests.get")
+def test_command_not_update_obsolete_object(mocked_api):
+    commune = CommuneFactory(code_insee="01001", obsolete=True)
+    assert commune.contour is None
+
+    call_command("update_geometry", write=True)
+    mocked_api.assert_not_called()


### PR DESCRIPTION
Add a command to update the geometry and the contours of the Commune object (municipalities).
This command takes about an hour or so due to the number of API calls.