### PR TITLE
Always sync user to Brevo

### DIFF
--- a/compte/service.py
+++ b/compte/service.py
@@ -5,9 +5,11 @@ from _datetime import timedelta
 from django.conf import settings
 from django.contrib.auth.hashers import make_password
 from django.db import DatabaseError, models
+from django.db.models import F
 from django.urls import reverse
 
-from compte.models import EmailToken
+from compte.models import EmailToken, UserStats
+from compte.tasks import sync_user_attributes
 from core.lib import text
 from core.mailer import BrevoMailer
 
@@ -74,3 +76,22 @@ def anonymize_user(user):
         return user
     except (ValueError, DatabaseError) as err:
         raise RuntimeError(f"Erreur lors de la suppression du compte utilisateur: {err}")
+
+
+def increment_nb_erp_created(user):
+    if not user:
+        return
+
+    user_stats, _ = UserStats.objects.get_or_create(user=user)
+    user_stats = F("nb_erp_created") + 1
+    user_stats.save()
+    sync_user_attributes.delay(user.pk)
+
+
+def increment_nb_erp_updated(user):
+    if not user:
+        return
+
+    user_stats, _ = UserStats.objects.get_or_create(user=user)
+    user_stats.nb_erp_edited = F("nb_erp_edited") + 1
+    user_stats.save()

--- a/compte/service.py
+++ b/compte/service.py
@@ -83,12 +83,12 @@ def increment_nb_erp_created(user):
         return
 
     user_stats, _ = UserStats.objects.get_or_create(user=user)
-    user_stats = F("nb_erp_created") + 1
+    user_stats.nb_erp_created = F("nb_erp_created") + 1
     user_stats.save()
     sync_user_attributes.delay(user.pk)
 
 
-def increment_nb_erp_updated(user):
+def increment_nb_erp_edited(user):
     if not user:
         return
 

--- a/erp/views.py
+++ b/erp/views.py
@@ -23,6 +23,7 @@ from django.views.generic import TemplateView
 from reversion.views import create_revision
 from waffle import switch_is_active
 
+from compte.service import increment_nb_erp_updated
 from compte.signals import erp_claimed
 from core.lib import geo, url
 from core.mailer import BrevoMailer, get_mailer
@@ -918,9 +919,12 @@ def contrib_edit_infos(request, erp_slug):
             erp = form.save(commit=False)
             activite = form.cleaned_data.get("activite")
             erp.activite = activite
-            if request.user.is_authenticated and erp.user is None:
-                erp.user = request.user
+            if request.user.is_authenticated:
+                if erp.user is None:
+                    erp.user = request.user
+                increment_nb_erp_updated(request.user)
             erp.save()
+
             if erp.has_miscellaneous_activity:
                 ActivitySuggestion.objects.create(
                     name=form.cleaned_data["nouvelle_activite"],

--- a/erp/views.py
+++ b/erp/views.py
@@ -23,7 +23,6 @@ from django.views.generic import TemplateView
 from reversion.views import create_revision
 from waffle import switch_is_active
 
-from compte.service import increment_nb_erp_updated
 from compte.signals import erp_claimed
 from core.lib import geo, url
 from core.mailer import BrevoMailer, get_mailer
@@ -840,9 +839,7 @@ def contrib_admin_infos(request):
                 erp.published = False
                 activite = form.cleaned_data.get("activite")
                 erp.activite = activite
-                if request.user.is_authenticated and erp.user is None:
-                    erp.user = request.user
-                erp.save()
+                erp.save(editor=request.user if request.user.is_authenticated else None)
                 if erp.has_miscellaneous_activity:
                     ActivitySuggestion.objects.create(
                         name=form.cleaned_data["nouvelle_activite"],
@@ -919,11 +916,7 @@ def contrib_edit_infos(request, erp_slug):
             erp = form.save(commit=False)
             activite = form.cleaned_data.get("activite")
             erp.activite = activite
-            if request.user.is_authenticated:
-                if erp.user is None:
-                    erp.user = request.user
-                increment_nb_erp_updated(request.user)
-            erp.save()
+            erp.save(editor=request.user if request.user.is_authenticated else None)
 
             if erp.has_miscellaneous_activity:
                 ActivitySuggestion.objects.create(
@@ -971,10 +964,7 @@ def contrib_a_propos(request, erp_slug):
             accessibilite.erp = erp
             accessibilite.save()
 
-            if request.user.is_authenticated and erp.user is None:
-                erp.user = request.user
-
-            erp.save()
+            erp.save(editor=request.user if request.user.is_authenticated else None)
             messages.add_message(
                 request,
                 messages.SUCCESS,

--- a/tests/erp/test_browser.py
+++ b/tests/erp/test_browser.py
@@ -277,6 +277,10 @@ def test_erp_edit_can_be_contributed(data, client):
 
 
 def test_ajout_erp(data, client):
+    data.niko.stats.refresh_from_db()
+    initial_nb_created = data.niko.stats.nb_erp_created
+    initial_nb_edited = data.niko.stats.nb_erp_edited
+
     response = client.get(reverse("contrib_start"))
     assert response.status_code == 200
 
@@ -506,7 +510,6 @@ def test_ajout_erp(data, client):
 
     # Publication
     # Public user
-    # TODO register during erp creation flow, check nb_erp_created
     client.force_login(data.niko)
     response = client.post(
         reverse("contrib_publication", kwargs={"erp_slug": erp.slug}),
@@ -520,6 +523,10 @@ def test_ajout_erp(data, client):
     assert erp.user == data.niko
     assert_redirect(response, erp.get_absolute_url())
     assert response.status_code == 200
+
+    data.niko.stats.refresh_from_db()
+    assert data.niko.stats.nb_erp_created == initial_nb_created + 1
+    assert data.niko.stats.nb_erp_edited == initial_nb_edited
 
 
 def test_ajout_erp_a11y_vide(data, client):
@@ -813,6 +820,10 @@ def test_history_human_readable_diff(data, client):
 
 
 def test_contribution_flow_administrative_data(data, client):
+    data.sophie.stats.refresh_from_db()
+    initial_nb_created = data.sophie.stats.nb_erp_created
+    initial_nb_edited = data.sophie.stats.nb_erp_edited
+
     client.force_login(data.sophie)
     response = client.get(reverse("contrib_edit_infos", kwargs={"erp_slug": data.erp.slug}))
 
@@ -844,6 +855,10 @@ def test_contribution_flow_administrative_data(data, client):
     assert updated_erp.user == data.erp.user  # original owner is preserved
     assert_redirect(response, "/contrib/transport/aux-bons-croissants/")
     assert response.status_code == 200
+
+    data.sophie.stats.refresh_from_db()
+    assert data.sophie.stats.nb_erp_created == initial_nb_created
+    assert data.sophie.stats.nb_erp_edited == initial_nb_edited + 1
 
 
 def test_contribution_flow_accessibilite_data(data, client):

--- a/tests/erp/test_browser.py
+++ b/tests/erp/test_browser.py
@@ -506,6 +506,7 @@ def test_ajout_erp(data, client):
 
     # Publication
     # Public user
+    # TODO register during erp creation flow, check nb_erp_created
     client.force_login(data.niko)
     response = client.post(
         reverse("contrib_publication", kwargs={"erp_slug": erp.slug}),


### PR DESCRIPTION
When following the nominal sign up funnel, while creating an ERP, the ERP is first created with no user, then the user is created and associated to the ERP. In that case we were not synch'ing user to Brevo as we were only synch'ing user when ERP is created.