### PR TITLE
Fix the "having label" filter

### DIFF
--- a/erp/managers.py
+++ b/erp/managers.py
@@ -396,7 +396,7 @@ class ErpQuerySet(models.QuerySet):
         return self.filter(accessibilite__accueil_equipements_malentendants_presence=True)
 
     def having_label(self):
-        return self.filter(accessibilite__labels__isnull=False)
+        return self.filter(accessibilite__labels__len__gt=0)
 
     def having_visible_reception(self):
         return self.filter(accessibilite__accueil_visibilite=True)

--- a/tests/erp/test_managers.py
+++ b/tests/erp/test_managers.py
@@ -6,7 +6,7 @@ from django.contrib.gis.geos import Point
 from erp import schema
 from erp.models import Accessibilite, Activite, Erp
 from erp.provider.search import get_equipments
-from tests.factories import AccessibiliteFactory
+from tests.factories import AccessibiliteFactory, ErpWithAccessibiliteFactory
 
 
 @pytest.fixture
@@ -214,3 +214,15 @@ class TestErpQuerySetFilters:
         for eq in get_equipments():
             with does_not_raise():
                 getattr(qs, eq)().count()
+
+    def test_having_label(self):
+        assert Erp.objects.having_label().count() == 0
+
+        ErpWithAccessibiliteFactory(accessibilite__labels=None)
+        assert Erp.objects.having_label().count() == 0
+
+        ErpWithAccessibiliteFactory(accessibilite__labels=[])
+        assert Erp.objects.having_label().count() == 0
+
+        ErpWithAccessibiliteFactory(accessibilite__labels=["dpt", "mobalib"])
+        assert Erp.objects.having_label().count() == 1


### PR DESCRIPTION
Fix the having label manager method, this will fix the corresponding having label filter in the search (and in the API).

The case that was not handled is when the labels array is set to an empty list ([]). This situation was not excluded by the "isnull" clause. Switch to using the length of the array and add tests.