### PR TITLE
Adjust sentence to reduce comment length

### DIFF
--- a/erp/management/commands/import_laposte.py
+++ b/erp/management/commands/import_laposte.py
@@ -33,17 +33,17 @@ mapping = {
     },
     "ACH00005": {
         "OUI": {
-            "commentaire": "Distributeur de billets disposant d'une prise audio pour les malvoyants.",
+            "commentaire": "GAB avec prise audio pour malvoyant.",
         }
     },
     "ACH00006": {
         "OUI": {
-            "commentaire": "Automate d'affranchissement disposant d'une prise audio pour les malvoyants.",
+            "commentaire": "Equipement affranchissement avec prise audio.",
         }
     },
     "ACH00008": {
         "OUI": {
-            "commentaire": "Présence d'une bande de guidage de l'entrée à l'accueil.",
+            "commentaire": "Bande de guidage intérieure.",
         }
     },
     "ACH00010": {
@@ -54,14 +54,14 @@ mapping = {
     },
     "ACH00012": {
         "OUI": {
-            "commentaire": "Présence d'une table pour écrire adaptée aux personnes en fauteuil roulant.",
+            "commentaire": "Guichet avec tablette PMR.",
         }
     },
     "ACH00013": {
         "OUI": {
-            "commentaire": "Présence d'un espace confidentiel accessible aux personnes en fauteuil roulant.",
+            "commentaire": "Présence d'un espace confidentiel accessible .",
         },
-        "NON": {"commentaire": "Il n'y a pas d'espace confidentiel accessible aux personnes en fauteuil roulant."},
+        "NON": {"commentaire": "Pas d'espace confidentiel accessible."},
     },
 }
 
@@ -88,7 +88,7 @@ class Command(BaseCommand):
                 continue
 
             if value in access_map:
-                new_access = access_map[value]
+                new_access = access_map[value].copy()
                 if "commentaire" in access_map[value] and accessibilite.get("commentaire"):
                     new_access["commentaire"] = f"{accessibilite.get('commentaire')} {access_map[value]['commentaire']}"
 

--- a/tests/erp/imports/test_import_laposte.py
+++ b/tests/erp/imports/test_import_laposte.py
@@ -10,6 +10,7 @@ from tests.factories import ActiviteFactory, CommuneFactory
 csv_file_contents = """"Libéllé de l'entité","Type de l'entité","Numéro et voie","Lieu-dit","Complément d'adresse","Code postal","Localité","Pays","ACH00002","ACH00014","ACH00015","ACH00009","ACH00003","ACH00010","ACH00011","ACH00004","ACH00007","ACH00001","ACH00008","ACH00012","ACH00005","ACH00006","ACH00013"
 "AMBERIEU EN BUGEY","BUREAU CENTRE","38 RUE ALEXANDRE BERARD","BP 602",,"01500","AMBERIEU EN BUGEY","FRANCE","OUI","OUI","OUI","OUI","NC","OUI","OUI","OUI","OUI","OUI","OUI","OUI","OUI","OUI","OUI"
 "AMBERIEU EN DOMBES BP","BUREAU DE POSTE","240 RUE GOMBETTE",,,"01330","AMBERIEUX EN DOMBES","FRANCE","NON","OUI","OUI","NC","NC","NON","OUI","OUI","NON","OUI","NON","NON","NC","NC","NON"
+"CEYZERIAT","BUREAU CENTRE","RUE JEROME LALANDE"," "," ","01250","CEYZERIAT","FRANCE","OUI","OUI","OUI","NC","NC","NON","OUI","NC","OUI","OUI","OUI","OUI","OUI","OUI","OUI"
 """
 
 
@@ -17,22 +18,23 @@ csv_file_contents = """"Libéllé de l'entité","Type de l'entité","Numéro et 
 def test_nominal_case():
     CommuneFactory(nom="AMBERIEU EN BUGEY")
     CommuneFactory(nom="AMBERIEUX EN DOMBES")
+    CommuneFactory(nom="CEYZERIAT")
     ActiviteFactory(nom="Bureau de Poste")
 
     with um.patch("builtins.open", um.mock_open(read_data=csv_file_contents)):
         call_command("import_laposte", file="mock")
-    assert Erp.objects.count() == 2
+    assert Erp.objects.count() == 3
 
     erp1 = Erp.objects.get(nom="La Poste", code_postal="01500")
     assert erp1.accessibilite.conformite is True
     assert erp1.accessibilite.entree_balise_sonore is True
     assert erp1.accessibilite.accueil_equipements_malentendants_presence is True
     assert erp1.accessibilite.accueil_equipements_malentendants == ["bim"]
-    assert "Présence d'une table pour écrire" in erp1.accessibilite.commentaire
+    assert "Guichet avec tablette PMR" in erp1.accessibilite.commentaire
     assert "Présence d'un espace confidentiel accessible" in erp1.accessibilite.commentaire
     assert "Pick up accessible aux PMR" not in erp1.accessibilite.commentaire
-    assert "Distributeur de billets disposant d'une prise audio" in erp1.accessibilite.commentaire
+    assert "GAB avec prise audio pour malvoyant" in erp1.accessibilite.commentaire
 
     erp2 = Erp.objects.get(nom="La Poste", code_postal="01330")
     assert erp2.accessibilite.conformite is False
-    assert "Il n'y a pas d'espace confidentiel accessible" in erp2.accessibilite.commentaire
+    assert "Pas d'espace confidentiel accessible" in erp2.accessibilite.commentaire


### PR DESCRIPTION
The comment attribute is limited to 1000 char. Adjust sentences to reduce the global comment length