### PR TITLE
Fix question display in contribution step

### DIFF
--- a/templates/contrib/7-commentaire.html
+++ b/templates/contrib/7-commentaire.html
@@ -51,7 +51,8 @@
           otherInput.value = "";
           otherInput.removeAttribute("required");
         }
-        if (checkedLabels.length > 0) {
+
+        if (checkedLabels.includes("th")) {
           fieldFamilles.classList.remove("hidden");
         } else {
           fieldFamilles.classList.add("hidden");


### PR DESCRIPTION
Make sure we ask the question on the "type de handicap" only when the "Tourisme et Handicap" label is checked. This question does not make any sense for the other labels.