### PR TITLE
Switch matomo graph to new server

### DIFF
--- a/templates/stats/index.html
+++ b/templates/stats/index.html
@@ -102,16 +102,16 @@
             <a class="btn-link fr-text--heavy" href="{% url 'challenges' %}">{% translate "Tout savoir" %}</a> {% translate "sur les challenges" %}
         </div>
     </aside>
-    {% switch 'DISPLAY_VISITS_GRAPH' %}
     <div class="mt-3">
         <h2 class="h5 my-3">
             {% translate "Fréquentation" %} <small class="text-muted">{% translate "sur les 30 derniers jours" %}</small>
         </h2>
         <iframe width="100%"
                 height="350"
-                title="Fréquentation du site"
-                src="https://stats.beta.gouv.fr/index.php?module=Widgetize&action=iframe&forceView=1&viewDataTable=graphEvolution&moduleToWidgetize=VisitsSummary&actionToWidgetize=getEvolutionGraph&idSite=3&period=day&date=yesterday&disableLink=1&widget=1"
-                scrolling="yes"></iframe>
+                src="https://stats.beta.gouv.fr/index.php?forceView=1&viewDataTable=graphEvolution&module=Widgetize&action=iframe&disableLink=1&widget=1&moduleToWidgetize=VisitsSummary&actionToWidgetize=getEvolutionGraph&idSite=3&period=day&date=yesterday"
+                scrolling="yes"
+                frameborder="0"
+                marginheight="0"
+                marginwidth="0"></iframe>
     </div>
-{% endswitch %}
 {% endblock editorial_content %}


### PR DESCRIPTION
We now use stats.beta to display the graph on the stats page.