### PR TITLE
Introduce new display of access data on ERP detail

### DIFF
--- a/erp/export/static/schema.json
+++ b/erp/export/static/schema.json
@@ -531,7 +531,7 @@
     {
       "name": "transport_station_presence",
       "title": "Proximité d'un arrêt de transport en commun",
-      "description": "Arrêt de transport en commun à moins de 200 mètres de l'établissement",
+      "description": "Transport en commun à proximité",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -562,7 +562,7 @@
     {
       "name": "stationnement_presence",
       "title": "Stationnement dans l'établissement",
-      "description": "Des places de stationnement sont disponibles au sein de la parcelle de l'établissement",
+      "description": "Places de parking au sein de l'établissement",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -593,7 +593,7 @@
     {
       "name": "stationnement_pmr",
       "title": "Stationnements adaptés dans l'établissement",
-      "description": "Des places de stationnement adaptées sont disponibles au sein de la parcelle de l'établissement",
+      "description": "Places de parking au sein de l'établissement comprenant des places PMR",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -624,7 +624,7 @@
     {
       "name": "stationnement_ext_presence",
       "title": "Stationnement à proximité de l'établissement",
-      "description": "Des places de stationnement sont disponibles à moins de 200 mètres de l'établissement",
+      "description": "Places de parking à proximité",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -655,7 +655,7 @@
     {
       "name": "stationnement_ext_pmr",
       "title": "Stationnements adaptés à proximité de l'établissement",
-      "description": "Des places de stationnement adaptées sont disponibles à moins de 200 mètres de l'établissement",
+      "description": "Places de parking à proximité comprenant des places PMR",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -686,7 +686,7 @@
     {
       "name": "cheminement_ext_presence",
       "title": "Chemin extérieur",
-      "description": "L'accès à l'entrée depuis la voirie se fait par un chemin extérieur",
+      "description": "Présence d'un chemin sur la parcelle de l'établissement qui mène à l'entrée",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -717,7 +717,7 @@
     {
       "name": "cheminement_ext_terrain_stable",
       "title": "Revêtement extérieur",
-      "description": "Le revêtement est stable (absence de pavés, gravillons, terre, herbe, sable, ou toute surface non stabilisée)",
+      "description": "Revêtement stable",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -817,7 +817,7 @@
     {
       "name": "cheminement_ext_reperage_marches",
       "title": "Marches ou escalier sécurisé(es)",
-      "description": "Présence de nez de marche contrastés, d'une bande d'éveil à la vigilance en haut de l'escalier et/ou de première et dernière contremarches contrastées",
+      "description": "Escalier sécurisé",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -858,7 +858,7 @@
     {
       "name": "cheminement_ext_main_courante",
       "title": "Main courante",
-      "description": "L'escalier est équipé d'une ou plusieurs main-courantes",
+      "description": "Équipé d'une ou plusieurs mains courantes",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -960,7 +960,7 @@
     {
       "name": "cheminement_ext_bande_guidage",
       "title": "Bande de guidage",
-      "description": "Présence d'une bande de guidage au sol facilitant le déplacement d'une personne aveugle ou malvoyante",
+      "description": "Bande de guidage",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -991,7 +991,7 @@
     {
       "name": "cheminement_ext_retrecissement",
       "title": "Rétrécissement du chemin",
-      "description": "Un ou plusieurs rétrécissements inférieurs à 90 centimètres du chemin pour atteindre la zone d'accueil",
+      "description": "Présence de rétrécissement inférieur à 90 cm sur le chemin",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -1022,7 +1022,7 @@
     {
       "name": "entree_reperage",
       "title": "Entrée facilement repérable",
-      "description": "L'entrée de l'établissement est facilement repérable",
+      "description": "Entrée bien visible",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -1053,7 +1053,7 @@
     {
       "name": "entree_vitree",
       "title": "Entrée vitrée",
-      "description": "La porte d'entrée est vitrée",
+      "description": "Porte vitrée",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -1084,7 +1084,7 @@
     {
       "name": "entree_vitree_vitrophanie",
       "title": "Repérage de la vitre",
-      "description": "Des éléments contrastés permettent de visualiser les parties vitrées de l'entrée",
+      "description": "Avec éléments contrastés sur la partie vitrée",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -1115,7 +1115,7 @@
     {
       "name": "entree_plain_pied",
       "title": "Entrée de plain-pied",
-      "description": "L'entrée se fait de plain-pied, c'est à dire sans rupture brutale de niveau",
+      "description": "Entrée de plain pied",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -1266,7 +1266,7 @@
     {
       "name": "entree_dispositif_appel",
       "title": "Dispositif d'appel à l'entrée",
-      "description": "Présence d'un dispositif comme une sonnette pour signaler sa présence",
+      "description": "Dispositif d'appel à l'entrée",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -1308,7 +1308,7 @@
     {
       "name": "entree_balise_sonore",
       "title": "Balise sonore à l'entrée",
-      "description": "Présence d'une balise sonore facilitant son repérage par une personne aveugle ou malvoyante",
+      "description": "Balise sonore",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -1339,7 +1339,7 @@
     {
       "name": "entree_aide_humaine",
       "title": "Aide humaine",
-      "description": "Possibilité d'une aide humaine au déplacement",
+      "description": "Aide humaine possible",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -1370,14 +1370,14 @@
     {
       "name": "entree_largeur_mini",
       "title": "Largeur de la porte",
-      "description": "Largeur minimale de la porte d'entrée",
+      "description": "Largeur d'au moins 80 cm",
       "type": "integer",
       "example": "0"
     },
     {
       "name": "entree_pmr",
       "title": "Entrée spécifique PMR",
-      "description": "Présence d'une entrée secondaire spécifique dédiée aux personnes à mobilité réduite",
+      "description": "Présence d'une entrée PMR",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -1459,7 +1459,7 @@
     {
       "name": "accueil_visibilite",
       "title": "Visibilité de la zone d'accueil",
-      "description": "La zone d'accueil (guichet d'accueil, caisse, secrétariat, etc) est visible depuis l'entrée du bâtiment",
+      "description": "Accueil à proximité direct de l'entrée",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -1547,7 +1547,7 @@
     {
       "name": "accueil_equipements_malentendants_presence",
       "title": "Présence d'équipements d'aide à l'audition et à la communication",
-      "description": "Présence de produits ou prestations dédiés aux personnes sourdes ou malentendantes",
+      "description": "Présence d'équipement d'aide à l'audition",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -1589,7 +1589,7 @@
     {
       "name": "accueil_cheminement_plain_pied",
       "title": "Chemin entre l'entrée principale du bâtiment et l'accueil de l'établissement",
-      "description": "L'accès à cet espace se fait de plain-pied, c'est à dire sans rupture brutale de niveau",
+      "description": "Chemin vers l'accueil de plain pied",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -1747,7 +1747,7 @@
     {
       "name": "accueil_chambre_douche_plain_pied",
       "title": "Douche accessible",
-      "description": "La douche est à l'italienne ou équipée d'un bac extra plat",
+      "description": "Douche à l'italienne (bac plat)",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -1778,7 +1778,7 @@
     {
       "name": "accueil_chambre_douche_siege",
       "title": "Siège de douche",
-      "description": "La douche est équipée d'un siège de douche",
+      "description": "Avec siège de douche",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -1809,7 +1809,7 @@
     {
       "name": "accueil_chambre_douche_barre_appui",
       "title": "Douche sécurisée",
-      "description": "La douche est équipée d'une barre d'appui horizontale",
+      "description": "Barre d'appui",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -1840,7 +1840,7 @@
     {
       "name": "accueil_chambre_sanitaires_barre_appui",
       "title": "Toilette sécurisé",
-      "description": "Le toilette est équipé d'une barre d'appui horizontale",
+      "description": "Avec Barre d'appui",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -1871,7 +1871,7 @@
     {
       "name": "accueil_chambre_sanitaires_espace_usage",
       "title": "Toilette accessible",
-      "description": "Le toilette dispose d'un espace d'usage à côté de la cuvette",
+      "description": "Avec espace d'usage",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -1902,7 +1902,7 @@
     {
       "name": "accueil_chambre_numero_visible",
       "title": "Visibilité des numéros de chambres",
-      "description": "Les numéros de chambres sont repérables et en relief",
+      "description": "Numéros de chambre en relief",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -1933,7 +1933,7 @@
     {
       "name": "accueil_chambre_equipement_alerte",
       "title": "Equipement d'alerte adapté",
-      "description": "L'établissement dispose d'un ou plusieurs équipements d'alerte par flash lumineux ou vibration",
+      "description": "Equipement d'alerte par flash lumineux ou vibration",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -1964,7 +1964,7 @@
     {
       "name": "accueil_chambre_accompagnement",
       "title": "Accompagnement spécifique",
-      "description": "Il est proposé un accompagnement personnalisé pour présenter la chambre à un client en situation de handicap, notamment aveugle ou malvoyant",
+      "description": "Accompagnement personnalisé pour présenter la chambre",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -1995,7 +1995,7 @@
     {
       "name": "accueil_retrecissement",
       "title": "Rétrécissement du chemin",
-      "description": "Présence d'un ou plusieurs rétrécissements inférieurs à 90 centimètres du chemin pour atteindre la zone d'accueil",
+      "description": "Présence de rétrécissement inférieur à 90 cm pour atteindre l'accueil",
       "type": "boolean",
       "trueValues": [
         "true",
@@ -2118,7 +2118,7 @@
     {
       "name": "conformite",
       "title": "Conformité",
-      "description": "L'établissement a été déclaré conforme à la réglementation",
+      "description": "Déclaré conforme à la réglementation",
       "type": "boolean",
       "trueValues": [
         "true",

--- a/erp/models.py
+++ b/erp/models.py
@@ -1682,3 +1682,14 @@ class Accessibilite(models.Model):
     @property
     def entrance_has_ramp(self):
         return self.entree_marches_rampe in (schema.RAMPE_FIXE, schema.RAMPE_AMOVIBLE)
+
+    def has_outside_path_and_no_other_data(self):
+        attrs = [
+            f.name
+            for f in Accessibilite._meta.get_fields()
+            if f.name.startswith("cheminement_ext_") and f.name != "cheminement_ext_presence"
+        ]
+        return self.cheminement_ext_presence and all([getattr(self, attr) is None for attr in attrs])
+
+    def has_camber(self):
+        return self.cheminement_ext_devers and self.cheminement_ext_devers != schema.DEVERS_AUCUN

--- a/erp/schema.py
+++ b/erp/schema.py
@@ -379,7 +379,7 @@ FIELDS = {
                 "Existe-t-il un arrêt de transport en commun à moins de 200 mètres de l'établissement&nbsp;?"
             )
         ),
-        "help_text_ui": translate_lazy("Arrêt de transport en commun à moins de 200 mètres de l'établissement"),
+        "help_text_ui": translate_lazy("Transport en commun à proximité"),
         "help_text_ui_neg": translate_lazy(
             "Pas d'arrêt de transport en commun à moins de 200 mètres de l'établissement"
         ),
@@ -421,12 +421,8 @@ FIELDS = {
                 "Existe-t-il une ou plusieurs places de stationnement dans l'établissement ou au sein de la parcelle de l'établissement&nbsp;?"
             )
         ),
-        "help_text_ui": translate_lazy(
-            "Des places de stationnement sont disponibles au sein de la parcelle de l'établissement"
-        ),
-        "help_text_ui_neg": translate_lazy(
-            "Pas de place de stationnement disponible au sein de la parcelle de l'établissement"
-        ),
+        "help_text_ui": translate_lazy("Places de parking au sein de l'établissement"),
+        "help_text_ui_neg": translate_lazy("Pas de places de parking au sein de l'établissement "),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_TRANSPORT,
         "nullable_bool": True,
@@ -444,9 +440,7 @@ FIELDS = {
                 "Existe-t-il une ou plusieurs places de stationnement adaptées dans l'établissement ou au sein de la parcelle de l'établissement&nbsp;?"
             )
         ),
-        "help_text_ui": translate_lazy(
-            "Des places de stationnement adaptées sont disponibles au sein de la parcelle de l'établissement"
-        ),
+        "help_text_ui": translate_lazy("Places de parking au sein de l'établissement comprenant des places PMR"),
         "help_text_ui_neg": translate_lazy(
             "Pas de place de stationnement disponible adaptée au sein de la parcelle de l'établissement"
         ),
@@ -467,12 +461,8 @@ FIELDS = {
                 "Existe-t-il une ou plusieurs places de stationnement en voirie ou en parking à moins de 200 mètres de l'établissement&nbsp;?"
             )
         ),
-        "help_text_ui": translate_lazy(
-            "Des places de stationnement sont disponibles à moins de 200 mètres de l'établissement"
-        ),
-        "help_text_ui_neg": translate_lazy(
-            "Pas de place de stationnement disponible à moins de 200 mètres de l'établissement"
-        ),
+        "help_text_ui": translate_lazy("Places de parking à proximité"),
+        "help_text_ui_neg": translate_lazy("Pas de places de parking à proximité"),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_TRANSPORT,
         "nullable_bool": True,
@@ -490,9 +480,7 @@ FIELDS = {
                 "Existe-t-il une ou plusieurs places de stationnement adaptées en voirie ou en parking à moins de 200 mètres de l'établissement&nbsp;?"
             )
         ),
-        "help_text_ui": translate_lazy(
-            "Des places de stationnement adaptées sont disponibles à moins de 200 mètres de l'établissement"
-        ),
+        "help_text_ui": translate_lazy("Places de parking à proximité comprenant des places PMR"),
         "help_text_ui_neg": translate_lazy(
             "Pas de place de stationnement disponible adaptée à moins de 200 mètres de l'établissement"
         ),
@@ -514,7 +502,7 @@ FIELDS = {
                 "Y-a-t-il un chemin extérieur entre le trottoir et l'entrée principale du bâtiment (exemple&nbsp;: une cour)&nbsp;?"
             )
         ),
-        "help_text_ui": translate_lazy("L'accès à l'entrée depuis la voirie se fait par un chemin extérieur"),
+        "help_text_ui": translate_lazy("Présence d'un chemin sur la parcelle de l'établissement qui mène à l'entrée"),
         "help_text_ui_neg": translate_lazy(
             "Pas de chemin extérieur entre le trottoir et l'entrée principale du bâtiment"
         ),
@@ -535,12 +523,8 @@ FIELDS = {
                 "Le revêtement du chemin extérieur (entre le trottoir et l'entrée de l'établissement) est-il stable (sol roulable, absence de pavés ou de gravillons, pas de terre ni d'herbe, etc.)&nbsp;?"
             )
         ),
-        "help_text_ui": translate_lazy(
-            "Le revêtement est stable (absence de pavés, gravillons, terre, herbe, sable, ou toute surface non stabilisée)"
-        ),
-        "help_text_ui_neg": translate_lazy(
-            "Le revêtement n'est pas stable (pavés, gravillons, terre, herbe, sable, ou toute surface non stabilisée)"
-        ),
+        "help_text_ui": translate_lazy("Revêtement stable"),
+        "help_text_ui_neg": translate_lazy("Revêtement meuble"),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_CHEMINEMENT_EXT,
         "nullable_bool": True,
@@ -577,7 +561,7 @@ FIELDS = {
         "is_a11y": True,
         "label": translate_lazy("Ascenseur/élévateur"),
         "help_text": mark_safe(translate_lazy("Existe-t-il un ascenseur ou un élévateur&nbsp;?")),
-        "help_text_ui": translate_lazy("Présence d'un ascenseur ou un élévateur"),
+        "help_text_ui": translate_lazy("Ascenseur ou élévateur"),
         "help_text_ui_neg": translate_lazy("Pas d'ascenseur ou d'élévateur"),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_CHEMINEMENT_EXT,
@@ -628,12 +612,8 @@ FIELDS = {
                 "L'escalier est-il sécurisé&nbsp;: nez de marche contrastés, bande d'éveil à la vigilance en haut de l'escalier, première et dernière contremarches contrastées&nbsp;?"
             )
         ),
-        "help_text_ui": translate_lazy(
-            "Présence de nez de marche contrastés, d'une bande d'éveil à la vigilance en haut de l'escalier et/ou de première et dernière contremarches contrastées"
-        ),
-        "help_text_ui_neg": translate_lazy(
-            "Pas de nez de marche contrasté, de bande d'éveil à la vigilance en haut de l'escalier ni de première et dernière contremarches contrastées"
-        ),
+        "help_text_ui": translate_lazy("Escalier sécurisé"),
+        "help_text_ui_neg": translate_lazy("Escalier non sécurisé"),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_CHEMINEMENT_EXT,
         "nullable_bool": True,
@@ -646,8 +626,8 @@ FIELDS = {
         "is_a11y": True,
         "label": translate_lazy("Main courante"),
         "help_text": mark_safe(translate_lazy("L'escalier est-il équipé d'une ou plusieurs main-courantes&nbsp;?")),
-        "help_text_ui": translate_lazy("L'escalier est équipé d'une ou plusieurs main-courantes"),
-        "help_text_ui_neg": translate_lazy("L'escalier n'est pas équipé de main-courante"),
+        "help_text_ui": translate_lazy("Équipé d'une ou plusieurs mains courantes"),
+        "help_text_ui_neg": translate_lazy("Non équipé de main courante."),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_CHEMINEMENT_EXT,
         "nullable_bool": True,
@@ -663,7 +643,7 @@ FIELDS = {
             translate_lazy("S'il existe une rampe ayant une pente douce, est-elle fixe ou amovible&nbsp;?")
         ),
         "help_text_ui": translate_lazy("Présence d'une rampe fixe ou amovible"),
-        "help_text_ui_neg": translate_lazy("Pas de rampe fixe ou amovible"),
+        "help_text_ui_neg": translate_lazy("Pas de rampe"),
         "choices": RAMPE_CHOICES,
         "section": SECTION_CHEMINEMENT_EXT,
         "nullable_bool": True,
@@ -722,7 +702,7 @@ FIELDS = {
             )
         ),
         "help_text_ui": translate_lazy("Dévers ou inclinaison transversale du chemin"),
-        "help_text_ui_neg": translate_lazy("Pas de dévers ou d'inclinaison transversale du chemin"),
+        "help_text_ui_neg": translate_lazy("Pas de dévers"),
         "choices": DEVERS_CHOICES,
         "section": SECTION_CHEMINEMENT_EXT,
         "nullable_bool": True,
@@ -739,9 +719,7 @@ FIELDS = {
                 "Présence d'une bande de guidage au sol facilitant le déplacement d'une personne aveugle ou malvoyante"
             )
         ),
-        "help_text_ui": translate_lazy(
-            "Présence d'une bande de guidage au sol facilitant le déplacement d'une personne aveugle ou malvoyante"
-        ),
+        "help_text_ui": translate_lazy("Bande de guidage"),
         "help_text_ui_neg": translate_lazy(
             "Pas de bande de guidage au sol facilitant le déplacement d'une personne aveugle ou malvoyante"
         ),
@@ -761,12 +739,8 @@ FIELDS = {
                 "Existe-t-il un ou plusieurs rétrécissements (inférieur à 90 centimètres) du chemin emprunté par le public pour atteindre l'entrée&nbsp;?"
             )
         ),
-        "help_text_ui": translate_lazy(
-            "Un ou plusieurs rétrécissements inférieurs à 90 centimètres du chemin pour atteindre la zone d'accueil"
-        ),
-        "help_text_ui_neg": translate_lazy(
-            "Pas de rétrécissement inférieur à 90 centimètres du chemin pour atteindre la zone d'accueil"
-        ),
+        "help_text_ui": translate_lazy("Présence de rétrécissement inférieur à 90 cm sur le chemin"),
+        "help_text_ui_neg": translate_lazy("Largeur minimale de 90 cm sur tout le chemin"),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_CHEMINEMENT_EXT,
         "nullable_bool": True,
@@ -784,10 +758,8 @@ FIELDS = {
                 "Y a-t-il des éléments facilitant le repérage de l'entrée de l'établissement (numéro de rue à proximité, enseigne, végétaux, éléments architecturaux contrastés, etc)&nbsp;?"
             )
         ),
-        "help_text_ui": translate_lazy("L'entrée de l'établissement est facilement repérable"),
-        "help_text_ui_neg": translate_lazy(
-            "Pas d'éléments facilitant le repérage de l'entrée de l'établissement (numéro de rue à proximité, enseigne, végétaux, éléments architecturaux contrastés, etc)"
-        ),
+        "help_text_ui": translate_lazy("Entrée bien visible"),
+        "help_text_ui_neg": translate_lazy("L'entrée n'est pas bien visible"),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_ENTREE,
         "nullable_bool": True,
@@ -802,7 +774,7 @@ FIELDS = {
         "label": translate_lazy("Y a-t-il une porte ?"),
         "help_text": mark_safe(translate_lazy("Y a-t-il une porte à l'entrée de l'établissement&nbsp;?")),
         "help_text_ui": translate_lazy("Présence d'une porte à l'entrée de l'établissement"),
-        "help_text_ui_neg": translate_lazy("Pas de porte à l'entrée de l'établissement"),
+        "help_text_ui_neg": translate_lazy("Pas de porte"),
         "choices": BOOLEAN_CHOICES,
         "section": SECTION_ENTREE,
         "nullable_bool": True,
@@ -845,7 +817,7 @@ FIELDS = {
         "is_a11y": True,
         "label": translate_lazy("Entrée vitrée"),
         "help_text": mark_safe(translate_lazy("La porte d'entrée est-elle vitrée&nbsp;?")),
-        "help_text_ui": translate_lazy("La porte d'entrée est vitrée"),
+        "help_text_ui": translate_lazy("Porte vitrée"),
         "help_text_ui_neg": translate_lazy("La porte d'entrée n'est pas vitrée"),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_ENTREE,
@@ -863,12 +835,8 @@ FIELDS = {
                 "Y a-t-il des éléments contrastés (autocollants, éléments de menuiserie ou autres) permettant de repérer la porte vitrée&nbsp;?"
             )
         ),
-        "help_text_ui": translate_lazy(
-            "Des éléments contrastés permettent de visualiser les parties vitrées de l'entrée"
-        ),
-        "help_text_ui_neg": translate_lazy(
-            "Pas d'éléments contrastés permettant de visualiser les parties vitrées de l'entrée"
-        ),
+        "help_text_ui": translate_lazy("Avec éléments contrastés sur la partie vitrée"),
+        "help_text_ui_neg": translate_lazy("Sans éléments contrastés sur la partie vitrée"),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_ENTREE,
         "nullable_bool": True,
@@ -885,7 +853,7 @@ FIELDS = {
                 "L'entrée est-elle de plain-pied, c'est-à-dire sans marche ni ressaut supérieur à 2 centimètres&nbsp;?"
             )
         ),
-        "help_text_ui": translate_lazy("L'entrée se fait de plain-pied, c'est à dire sans rupture brutale de niveau"),
+        "help_text_ui": translate_lazy("Entrée de plain pied"),
         "help_text_ui_neg": translate_lazy(
             "L'entrée n'est pas de plain-pied et présente une rupture brutale de niveau"
         ),
@@ -984,7 +952,7 @@ FIELDS = {
             translate_lazy("S'il existe une rampe ayant une pente douce, est-elle fixe ou amovible&nbsp;?")
         ),
         "help_text_ui": translate_lazy("Présence d'une rampe fixe ou amovible"),
-        "help_text_ui_neg": translate_lazy("Pas de rampe fixe ou amovible"),
+        "help_text_ui_neg": translate_lazy("Pas de rampe"),
         "choices": RAMPE_CHOICES,
         "section": SECTION_ENTREE,
         "nullable_bool": True,
@@ -1001,7 +969,7 @@ FIELDS = {
                 "Existe-t-il un dispositif pour permettre à quelqu'un signaler sa présence à l'entrée&nbsp;?"
             )
         ),
-        "help_text_ui": translate_lazy("Présence d'un dispositif comme une sonnette pour signaler sa présence"),
+        "help_text_ui": translate_lazy("Dispositif d'appel à l'entrée"),
         "help_text_ui_neg": translate_lazy("Pas de dispositif comme une sonnette pour signaler sa présence"),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_ENTREE,
@@ -1034,9 +1002,7 @@ FIELDS = {
                 "L'entrée est-elle équipée d'une balise sonore facilitant son repérage par une personne aveugle ou malvoyante&nbsp;?"
             )
         ),
-        "help_text_ui": translate_lazy(
-            "Présence d'une balise sonore facilitant son repérage par une personne aveugle ou malvoyante"
-        ),
+        "help_text_ui": translate_lazy("Balise sonore"),
         "help_text_ui_neg": translate_lazy(
             "Pas de balise sonore facilitant son repérage par une personne aveugle ou malvoyante"
         ),
@@ -1053,7 +1019,7 @@ FIELDS = {
         "is_a11y": True,
         "label": translate_lazy("Aide humaine"),
         "help_text": mark_safe(translate_lazy("Présence ou possibilité d'une aide humaine au déplacement")),
-        "help_text_ui": translate_lazy("Possibilité d'une aide humaine au déplacement"),
+        "help_text_ui": translate_lazy("Aide humaine possible"),
         "help_text_ui_neg": translate_lazy("Pas de possibilité d'aide humaine au déplacement"),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_ENTREE,
@@ -1072,8 +1038,8 @@ FIELDS = {
                 "Si la largeur n'est pas précisément connue, indiquer une valeur minimum. Exemple&nbsp;: la largeur se situe entre 90 et 100 centimètres&nbsp;; indiquer 90."
             )
         ),
-        "help_text_ui": translate_lazy("Largeur minimale de la porte d'entrée"),
-        "help_text_ui_neg": translate_lazy("Largeur minimale de la porte d'entrée"),
+        "help_text_ui": translate_lazy("Largeur d'au moins 80 cm"),
+        "help_text_ui_neg": translate_lazy("Largeur inférieure à 80 cm"),
         "choices": None,
         "unit": "centimètre",
         "section": SECTION_ENTREE,
@@ -1092,9 +1058,7 @@ FIELDS = {
                 "Existe-t-il une entrée secondaire spécifique dédiée aux personnes à mobilité réduite&nbsp;?"
             )
         ),
-        "help_text_ui": translate_lazy(
-            "Présence d'une entrée secondaire spécifique dédiée aux personnes à mobilité réduite"
-        ),
+        "help_text_ui": translate_lazy("Présence d'une entrée PMR"),
         "help_text_ui_neg": translate_lazy(
             "Pas d'entrée secondaire spécifique dédiée aux personnes à mobilité réduite"
         ),
@@ -1131,12 +1095,8 @@ FIELDS = {
                 "La zone d'accueil (guichet d'accueil, caisse, secrétariat, etc) est-elle visible depuis l'entrée du bâtiment&nbsp;?"
             )
         ),
-        "help_text_ui": translate_lazy(
-            "La zone d'accueil (guichet d'accueil, caisse, secrétariat, etc) est visible depuis l'entrée du bâtiment"
-        ),
-        "help_text_ui_neg": translate_lazy(
-            "La zone d'accueil (guichet d'accueil, caisse, secrétariat, etc) n'est pas visible depuis l'entrée du bâtiment"
-        ),
+        "help_text_ui": translate_lazy("Accueil à proximité direct de l'entrée"),
+        "help_text_ui_neg": translate_lazy("Accueil éloigné de l'entrée"),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_ACCUEIL,
         "nullable_bool": True,
@@ -1154,9 +1114,7 @@ FIELDS = {
                 "Une fois l'entrée du bâtiment passée, le chemin jusqu'à l'accueil de l'établissement est t-il de plain-pied, c'est-à-dire sans marche ni ressaut supérieur à 2 centimètres&nbsp;? (attention, plain-pied ne signifie pas plat mais sans rupture brutale de niveau)"
             )
         ),
-        "help_text_ui": translate_lazy(
-            "L'accès à cet espace se fait de plain-pied, c'est à dire sans rupture brutale de niveau"
-        ),
+        "help_text_ui": translate_lazy("Chemin vers l'accueil de plain pied"),
         "help_text_ui_neg": translate_lazy(
             "L'accès à cet espace n'est pas de plain-pied et présente une rupture brutale de niveau"
         ),
@@ -1271,12 +1229,8 @@ FIELDS = {
                 "Existe-t-il un ou plusieurs rétrécissements (inférieur à 90 centimètres) du chemin emprunté par le public pour atteindre la zone d'accueil&nbsp;?"
             )
         ),
-        "help_text_ui": translate_lazy(
-            "Présence d'un ou plusieurs rétrécissements inférieurs à 90 centimètres du chemin pour atteindre la zone d'accueil"
-        ),
-        "help_text_ui_neg": translate_lazy(
-            "Pas de rétrécissement inférieur à 90 centimètres du chemin pour atteindre la zone d'accueil"
-        ),
+        "help_text_ui": translate_lazy("Présence de rétrécissement inférieur à 90 cm pour atteindre l'accueil"),
+        "help_text_ui_neg": translate_lazy("Largeur minimale de 90 cm sur toute la circulation menant à l'accueil"),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_ACCUEIL,
         "nullable_bool": True,
@@ -1295,7 +1249,7 @@ FIELDS = {
             )
         ),
         "help_text_ui": translate_lazy("Nombre de chambres accessibles à une personne en fauteuil roulant"),
-        "help_text_ui_neg": translate_lazy("Aucune chambre accessible à une personne en fauteuil roulant"),
+        "help_text_ui_neg": translate_lazy("Pas de chambre accessible"),
         "choices": None,
         "unit": "chambre",
         "section": SECTION_ACCUEIL,
@@ -1315,8 +1269,8 @@ FIELDS = {
                 "La douche est-elle à l'italienne ou équipée d'un bac extra plat (hauteur inférieure à 2 cm)&nbsp;?"
             )
         ),
-        "help_text_ui": translate_lazy("La douche est à l'italienne ou équipée d'un bac extra plat"),
-        "help_text_ui_neg": translate_lazy("La douche n'est pas à l'italienne ni équipée d'un bac extra plat"),
+        "help_text_ui": translate_lazy("Douche à l'italienne (bac plat)"),
+        "help_text_ui_neg": translate_lazy("Douche classique, avec ressaut ou marche"),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_ACCUEIL,
         "nullable_bool": True,
@@ -1335,8 +1289,8 @@ FIELDS = {
                 "La douche est-elle équipée d'un siège de douche normé et d'une largeur minimum de 40 cm&nbsp;?"
             )
         ),
-        "help_text_ui": translate_lazy("La douche est équipée d'un siège de douche"),
-        "help_text_ui_neg": translate_lazy("La douche n'est pas équipée d'un siège de douche"),
+        "help_text_ui": translate_lazy("Avec siège de douche"),
+        "help_text_ui_neg": translate_lazy("Sans siège de douche"),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_ACCUEIL,
         "nullable_bool": True,
@@ -1355,8 +1309,8 @@ FIELDS = {
                 "La douche est-elle équipée d'une barre d'appui horizontale permettant le transfert depuis un fauteuil vers le siège de douche&nbsp;?"
             )
         ),
-        "help_text_ui": translate_lazy("La douche est équipée d'une barre d'appui horizontale"),
-        "help_text_ui_neg": translate_lazy("La douche n'est pas équipée d'une barre d'appui horizontale"),
+        "help_text_ui": translate_lazy("Barre d'appui"),
+        "help_text_ui_neg": translate_lazy("Sans barre d'appui"),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_ACCUEIL,
         "nullable_bool": True,
@@ -1371,8 +1325,8 @@ FIELDS = {
         "is_a11y": True,
         "label": translate_lazy("Toilette sécurisé"),
         "help_text": mark_safe(translate_lazy("Le toilette est-il équipé d'une barre d'appui horizontale&nbsp;?")),
-        "help_text_ui": translate_lazy("Le toilette est équipé d'une barre d'appui horizontale"),
-        "help_text_ui_neg": translate_lazy("Le toilette n'est pas équipé d'une barre d'appui horizontale"),
+        "help_text_ui": translate_lazy("Avec Barre d'appui"),
+        "help_text_ui_neg": translate_lazy("Sans barre d'appui"),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_ACCUEIL,
         "nullable_bool": True,
@@ -1389,8 +1343,8 @@ FIELDS = {
         "help_text": mark_safe(
             translate_lazy("Le toilette dispose-t-il d'un espace d'usage (80 cm x 130 cm) à côté de la cuvette&nbsp;?")
         ),
-        "help_text_ui": translate_lazy("Le toilette dispose d'un espace d'usage à côté de la cuvette"),
-        "help_text_ui_neg": translate_lazy("Le toilette ne dispose pas d'un espace d'usage à côté de la cuvette"),
+        "help_text_ui": translate_lazy("Avec espace d'usage"),
+        "help_text_ui_neg": translate_lazy("Sans espace d'usage"),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_ACCUEIL,
         "nullable_bool": True,
@@ -1409,8 +1363,8 @@ FIELDS = {
                 "Les numéros de chambres sont-ils bien repérables et en relief (très contrastés, positionnés à hauteur des yeux, soit 160 cm, au milieu de la porte ou au-dessus de la poignée, et relief d’au moins 2 cm d’épaisseur) ?"
             )
         ),
-        "help_text_ui": translate_lazy("Les numéros de chambres sont repérables et en relief"),
-        "help_text_ui_neg": translate_lazy("Les numéros de chambres ne sont pas repérables et en relief"),
+        "help_text_ui": translate_lazy("Numéros de chambre en relief"),
+        "help_text_ui_neg": translate_lazy("Numéros de chambre sans relief"),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_ACCUEIL,
         "nullable_bool": True,
@@ -1429,12 +1383,8 @@ FIELDS = {
                 "L'établissement dispose-t-il d'un ou plusieurs équipements d'alerte par flash lumineux ou vibration&nbsp;?"
             )
         ),
-        "help_text_ui": translate_lazy(
-            "L'établissement dispose d'un ou plusieurs équipements d'alerte par flash lumineux ou vibration"
-        ),
-        "help_text_ui_neg": translate_lazy(
-            "L'établissement ne dispose pas d'équipement d'alerte par flash lumineux ou vibration"
-        ),
+        "help_text_ui": translate_lazy("Equipement d'alerte par flash lumineux ou vibration"),
+        "help_text_ui_neg": translate_lazy("Pas d'équipement d'alerte par flash lumineux ou vibration"),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_ACCUEIL,
         "nullable_bool": True,
@@ -1453,11 +1403,9 @@ FIELDS = {
                 "Est-il proposé un accompagnement personnalisé pour présenter la chambre à un client en situation de handicap, notamment aveugle ou malvoyant&nbsp;?"
             )
         ),
-        "help_text_ui": translate_lazy(
-            "Il est proposé un accompagnement personnalisé pour présenter la chambre à un client en situation de handicap, notamment aveugle ou malvoyant"
-        ),
+        "help_text_ui": translate_lazy("Accompagnement personnalisé pour présenter la chambre"),
         "help_text_ui_neg": translate_lazy(
-            "Aucun accompagnement personnalisé pour présenter la chambre à un client en situation de handicap n'est proposé"
+            "Pas de possibilité d'accompagnement personnalisé pour présenter la chambre"
         ),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_ACCUEIL,
@@ -1498,7 +1446,7 @@ FIELDS = {
         "label": translate_lazy("Audiodescription"),
         "help_text": mark_safe(translate_lazy("L'établissement propose-t-il de l’audiodescription&nbsp?")),
         "help_text_ui": translate_lazy("L'établissement propose l'audiodescription"),
-        "help_text_ui_neg": translate_lazy("L'établissement ne propose pas l’audiodescription"),
+        "help_text_ui_neg": translate_lazy("Pas d'audiodescription"),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_ACCUEIL,
         "nullable_bool": True,
@@ -1529,12 +1477,8 @@ FIELDS = {
                 "L'accueil est-il équipé de produits ou prestations dédiés aux personnes sourdes ou malentendantes&nbsp?"
             )
         ),
-        "help_text_ui": translate_lazy(
-            "Présence de produits ou prestations dédiés aux personnes sourdes ou malentendantes"
-        ),
-        "help_text_ui_neg": translate_lazy(
-            "Pas de produits ou prestations dédiés aux personnes sourdes ou malentendantes"
-        ),
+        "help_text_ui": translate_lazy("Présence d'équipement d'aide à l'audition"),
+        "help_text_ui_neg": translate_lazy("Pas d'équipement d'aide à l'audition"),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_ACCUEIL,
         "nullable_bool": True,
@@ -1568,7 +1512,7 @@ FIELDS = {
         "label": translate_lazy("Sanitaires"),
         "help_text": mark_safe(translate_lazy("Y a-t-il des sanitaires mis à disposition du public&nbsp;?")),
         "help_text_ui": translate_lazy("Des sanitaires sont mis à disposition dans l'établissement"),
-        "help_text_ui_neg": translate_lazy("Pas de sanitaires mis à disposition dans l'établissement"),
+        "help_text_ui_neg": translate_lazy("Absence de toilettes"),
         "choices": NULLABLE_BOOLEAN_CHOICES,
         "section": SECTION_ACCUEIL,
         "nullable_bool": True,
@@ -1694,7 +1638,7 @@ FIELDS = {
         "help_text": mark_safe(
             translate_lazy("L'établissement est-il déclaré conforme ? (réservé à l'administration)")
         ),
-        "help_text_ui": translate_lazy("L'établissement a été déclaré conforme à la réglementation"),
+        "help_text_ui": translate_lazy("Déclaré conforme à la réglementation"),
         "help_text_ui_neg": translate_lazy(
             "l'établissement n'a pas été déclaré conforme à la réglementation auprès de l'administration"
         ),

--- a/erp/templatetags/a4a.py
+++ b/erp/templatetags/a4a.py
@@ -121,6 +121,28 @@ def get_field_label(value):
     return schema.get_label(value) or forms.get_label(value)
 
 
+@register.filter(name="positive_text")
+def positive_text(value):
+    return schema.get_help_text_ui(value)
+
+
+@register.filter(name="negative_text")
+def negative_text(value):
+    return schema.get_help_text_ui_neg(value)
+
+
+@register.simple_tag
+def access_text(value_name, access):
+    if getattr(access, value_name):
+        return schema.get_help_text_ui(value_name)
+    return schema.get_help_text_ui_neg(value_name)
+
+
+@register.inclusion_tag("erp/includes/access_value.html")
+def render_access_value(value_name, access):
+    return {"value_name": value_name, "access": access, "value": getattr(access, value_name)}
+
+
 @register.simple_tag
 def render_field(value):
     return (isinstance(value, list) and len(value) > 0) or (

--- a/erp/views.py
+++ b/erp/views.py
@@ -409,6 +409,7 @@ def erp_details(request, commune, erp_slug, activite_slug=None):
             "commune_json": erp.commune_ext.toTemplateJson() if erp.commune_ext else None,
             "erp": erp,
             "geojson_list": make_geojson([erp]),
+            "access": erp.accessibilite,
             "widget_tag": widget_tag,
             "url_widget_js": url_widget_js,
             "root_url": settings.SITE_ROOT_URL,
@@ -423,6 +424,7 @@ def erp_details(request, commune, erp_slug, activite_slug=None):
                     "dragging": False,
                 }
             ),
+            "show_new_access_data": request.GET.get("v2", "") != "",
         },
     )
 

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-18 11:47+0100\n"
-"PO-Revision-Date: 2024-03-18 11:46+0100\n"
+"POT-Creation-Date: 2024-03-18 10:38+0100\n"
+"PO-Revision-Date: 2024-02-28 10:26+0100\n"
 "Last-Translator: Marie-Laure3 Vernay <mlvernay@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -1399,9 +1399,6 @@ msgstr "Proximity to a public transportation stop"
 msgid "Existe-t-il un arrêt de transport en commun à moins de 200 mètres de l'établissement&nbsp;?"
 msgstr "Is there a public transportation stop within 200 meters of the facility?"
 
-msgid "Arrêt de transport en commun à moins de 200 mètres de l'établissement"
-msgstr "Public transportation stops within 200 meters of the facility"
-
 msgid "Pas d'arrêt de transport en commun à moins de 200 mètres de l'établissement"
 msgstr "No public transportation stops within 200 meters of the facility"
 
@@ -1420,11 +1417,11 @@ msgstr "Parking in the facility"
 msgid "Existe-t-il une ou plusieurs places de stationnement dans l'établissement ou au sein de la parcelle de l'établissement&nbsp;?"
 msgstr "Is there one or more parking spaces in the facility or within the facility grounds?"
 
-msgid "Des places de stationnement sont disponibles au sein de la parcelle de l'établissement"
-msgstr "Parking is available within the facility's grounds"
+msgid "Places de parking au sein de l'établissement"
+msgstr ""
 
-msgid "Pas de place de stationnement disponible au sein de la parcelle de l'établissement"
-msgstr "No parking spaces available within the facility's grounds"
+msgid "Pas de places de parking au sein de l'établissement "
+msgstr "No parking spaces available within the facility"
 
 msgid "Stationnements adaptés dans l'établissement"
 msgstr "Adapted parkings in the facility"
@@ -1432,8 +1429,8 @@ msgstr "Adapted parkings in the facility"
 msgid "Existe-t-il une ou plusieurs places de stationnement adaptées dans l'établissement ou au sein de la parcelle de l'établissement&nbsp;?"
 msgstr "Is there one or more adapted parking spaces in the facility or within the facility grounds?"
 
-msgid "Des places de stationnement adaptées sont disponibles au sein de la parcelle de l'établissement"
-msgstr "Adapted parking spaces are available within the facility's grounds"
+msgid "Places de parking au sein de l'établissement comprenant des places PMR"
+msgstr ""
 
 msgid "Pas de place de stationnement disponible adaptée au sein de la parcelle de l'établissement"
 msgstr "No suitable parking space available within the facility's grounds"
@@ -1444,11 +1441,11 @@ msgstr "Parking near the facility"
 msgid "Existe-t-il une ou plusieurs places de stationnement en voirie ou en parking à moins de 200 mètres de l'établissement&nbsp;?"
 msgstr "Is there one or more on-street or off-street parking spaces within 200 meters of the facility?"
 
-msgid "Des places de stationnement sont disponibles à moins de 200 mètres de l'établissement"
-msgstr "Parking is available within 200 meters of the facility"
+msgid "Places de parking à proximité"
+msgstr "Parking spaces nearby"
 
-msgid "Pas de place de stationnement disponible à moins de 200 mètres de l'établissement"
-msgstr "No parking space available within 200 meters of the facility"
+msgid "Pas de places de parking à proximité"
+msgstr "No adapted parking spaces nearby"
 
 msgid "Stationnements adaptés à proximité de l'établissement"
 msgstr "Adapted parking close to the facility"
@@ -1456,8 +1453,8 @@ msgstr "Adapted parking close to the facility"
 msgid "Existe-t-il une ou plusieurs places de stationnement adaptées en voirie ou en parking à moins de 200 mètres de l'établissement&nbsp;?"
 msgstr "Is there one or more adapted parking spaces on the road or in a parking lot within 200 meters of the facility?"
 
-msgid "Des places de stationnement adaptées sont disponibles à moins de 200 mètres de l'établissement"
-msgstr "Adapted parking spaces are available within 200 meters of the facility"
+msgid "Places de parking à proximité comprenant des places PMR"
+msgstr ""
 
 msgid "Pas de place de stationnement disponible adaptée à moins de 200 mètres de l'établissement"
 msgstr "No suitable parking space available within 200 meters of the facility"
@@ -1465,8 +1462,8 @@ msgstr "No suitable parking space available within 200 meters of the facility"
 msgid "Y-a-t-il un chemin extérieur entre le trottoir et l'entrée principale du bâtiment (exemple&nbsp;: une cour)&nbsp;?"
 msgstr "Is there an exterior path between the sidewalk and the main entrance of the facility (example: a yard)?"
 
-msgid "L'accès à l'entrée depuis la voirie se fait par un chemin extérieur"
-msgstr "Access to the entrance from the road is via an outside path"
+msgid "Présence d'un chemin sur la parcelle de l'établissement qui mène à l'entrée"
+msgstr ""
 
 msgid "Pas de chemin extérieur entre le trottoir et l'entrée principale du bâtiment"
 msgstr "No exterior path from the sidewalk to the main entrance of the building"
@@ -1477,11 +1474,11 @@ msgstr "Exterior cladding"
 msgid "Le revêtement du chemin extérieur (entre le trottoir et l'entrée de l'établissement) est-il stable (sol roulable, absence de pavés ou de gravillons, pas de terre ni d'herbe, etc.)&nbsp;?"
 msgstr "Is the surface of the outside path (between the sidewalk and the entrance of the facility) stable (rollable ground, no paving stones or gravel, no dirt or grass, etc.)?"
 
-msgid "Le revêtement est stable (absence de pavés, gravillons, terre, herbe, sable, ou toute surface non stabilisée)"
-msgstr "The pavement is stable (no paving stones, gravel, dirt, grass, sand, or any unstabilized surface)"
+msgid "Revêtement stable"
+msgstr ""
 
-msgid "Le revêtement n'est pas stable (pavés, gravillons, terre, herbe, sable, ou toute surface non stabilisée)"
-msgstr "The surface is not stable (paving stones, gravel, earth, grass, sand, or any other non-stabilized surface)"
+msgid "Revêtement meuble"
+msgstr ""
 
 msgid "Chemin extérieur de plain-pied"
 msgstr "Outside walkway on ground-level"
@@ -1497,9 +1494,6 @@ msgstr "The access to this space is not on the same level and presents a brutal 
 
 msgid "Existe-t-il un ascenseur ou un élévateur&nbsp;?"
 msgstr "Is there an elevator?"
-
-msgid "Présence d'un ascenseur ou un élévateur"
-msgstr "Presence of an elevator"
 
 msgid "Pas d'ascenseur ou d'élévateur"
 msgstr "No elevator"
@@ -1528,20 +1522,20 @@ msgstr "Secure steps or staircase"
 msgid "L'escalier est-il sécurisé&nbsp;: nez de marche contrastés, bande d'éveil à la vigilance en haut de l'escalier, première et dernière contremarches contrastées&nbsp;?"
 msgstr "Is the staircase safe: contrasting stair nosings, warning strips at the top of the stairs, contrasting first and last risers?"
 
-msgid "Présence de nez de marche contrastés, d'une bande d'éveil à la vigilance en haut de l'escalier et/ou de première et dernière contremarches contrastées"
-msgstr "Presence of contrasting stair nosings, a warning strip at the top of the stairs and/or contrasting first and last risers"
+msgid "Escalier sécurisé"
+msgstr ""
 
-msgid "Pas de nez de marche contrasté, de bande d'éveil à la vigilance en haut de l'escalier ni de première et dernière contremarches contrastées"
-msgstr "No contrasting stair nosing, warning strips at the top of the stairs or contrasting first and last risers"
+msgid "Escalier non sécurisé"
+msgstr ""
 
 msgid "L'escalier est-il équipé d'une ou plusieurs main-courantes&nbsp;?"
 msgstr "Is the staircase equipped with one or more handrails?"
 
-msgid "L'escalier est équipé d'une ou plusieurs main-courantes"
-msgstr "The staircase is equipped with one or more handrails"
+msgid "Équipé d'une ou plusieurs mains courantes"
+msgstr "Equipped with one or more handrails"
 
-msgid "L'escalier n'est pas équipé de main-courante"
-msgstr "The staircase is not equipped with a handrail"
+msgid "Non équipé de main courante."
+msgstr "Not equipped with a handrail"
 
 msgid "S'il existe une rampe ayant une pente douce, est-elle fixe ou amovible&nbsp;?"
 msgstr "If there is a ramp with a gentle slope, is it stationary or removable?"
@@ -1549,8 +1543,8 @@ msgstr "If there is a ramp with a gentle slope, is it stationary or removable?"
 msgid "Présence d'une rampe fixe ou amovible"
 msgstr "Presence of a stationary or removable ramp"
 
-msgid "Pas de rampe fixe ou amovible"
-msgstr "No stationary or removable ramps"
+msgid "Pas de rampe"
+msgstr "No ramp"
 
 msgid "Pente"
 msgstr "Slope"
@@ -1576,8 +1570,8 @@ msgstr "A camber is a transverse inclination of the path. If there is one, what 
 msgid "Dévers ou inclinaison transversale du chemin"
 msgstr "Camber or cross slope of the road"
 
-msgid "Pas de dévers ou d'inclinaison transversale du chemin"
-msgstr "No camber or cross slope of the path"
+msgid "Pas de dévers"
+msgstr ""
 
 msgid "Présence d'une bande de guidage au sol facilitant le déplacement d'une personne aveugle ou malvoyante"
 msgstr "Presence of a guiding strip on the ground facilitating the movement of a blind or visually impaired person"
@@ -1591,20 +1585,20 @@ msgstr "Path narrowing"
 msgid "Existe-t-il un ou plusieurs rétrécissements (inférieur à 90 centimètres) du chemin emprunté par le public pour atteindre l'entrée&nbsp;?"
 msgstr "Is there a narrowing or several narrowings (less than 90 centimeters) in the path used by the public to reach the entrance?"
 
-msgid "Un ou plusieurs rétrécissements inférieurs à 90 centimètres du chemin pour atteindre la zone d'accueil"
-msgstr "One or more narrowings of less than 90 centimeters in the path to the reception area"
+msgid "Présence de rétrécissement inférieur à 90 cm sur le chemin"
+msgstr "Path narrowing to the reception area by less than 90 centimeters"
 
-msgid "Pas de rétrécissement inférieur à 90 centimètres du chemin pour atteindre la zone d'accueil"
-msgstr "No path narrowing to the reception area by less than 90 centimeters"
+msgid "Largeur minimale de 90 cm sur tout le chemin"
+msgstr ""
 
 msgid "Y a-t-il des éléments facilitant le repérage de l'entrée de l'établissement (numéro de rue à proximité, enseigne, végétaux, éléments architecturaux contrastés, etc)&nbsp;?"
 msgstr "Are there elements that facilitate the identification of the entrance to the facility (street number nearby, sign, vegetation, contrasting architectural elements, etc.)?"
 
-msgid "L'entrée de l'établissement est facilement repérable"
-msgstr "The facility entrance is easily identifiable"
+msgid "Entrée bien visible"
+msgstr ""
 
-msgid "Pas d'éléments facilitant le repérage de l'entrée de l'établissement (numéro de rue à proximité, enseigne, végétaux, éléments architecturaux contrastés, etc)"
-msgstr "No elements that facilitate the identification of the facility entrance (street number nearby, sign, vegetation, contrasting architectural elements, etc.)"
+msgid "L'entrée n'est pas bien visible"
+msgstr ""
 
 msgid "Y a-t-il une porte ?"
 msgstr "Is there a door?"
@@ -1614,9 +1608,6 @@ msgstr "Is there a door at the facility entrance?"
 
 msgid "Présence d'une porte à l'entrée de l'établissement"
 msgstr "Presence of a door at the facility entrance"
-
-msgid "Pas de porte à l'entrée de l'établissement"
-msgstr "No door at the facility entrance"
 
 msgid "Manoeuvre de la porte"
 msgstr "Door handling"
@@ -1633,8 +1624,8 @@ msgstr "What is the type of door?"
 msgid "La porte d'entrée est-elle vitrée&nbsp;?"
 msgstr "Is the front door glazed?"
 
-msgid "La porte d'entrée est vitrée"
-msgstr "The front door is glazed"
+msgid "Porte vitrée"
+msgstr ""
 
 msgid "La porte d'entrée n'est pas vitrée"
 msgstr "The front door is not glazed"
@@ -1645,17 +1636,17 @@ msgstr "Identification of the glass"
 msgid "Y a-t-il des éléments contrastés (autocollants, éléments de menuiserie ou autres) permettant de repérer la porte vitrée&nbsp;?"
 msgstr "Are there any contrasting elements (stickers, woodwork or other elements) to identify the glazed door?"
 
-msgid "Des éléments contrastés permettent de visualiser les parties vitrées de l'entrée"
-msgstr "Contrasting elements make it possible to visualize the glazed parts of the entrance"
+msgid "Avec éléments contrastés sur la partie vitrée"
+msgstr ""
 
-msgid "Pas d'éléments contrastés permettant de visualiser les parties vitrées de l'entrée"
-msgstr "No contrasting elements to visualize the glazed parts of the entrance"
+msgid "Sans éléments contrastés sur la partie vitrée"
+msgstr ""
 
 msgid "L'entrée est-elle de plain-pied, c'est-à-dire sans marche ni ressaut supérieur à 2 centimètres&nbsp;?"
 msgstr "Is the entrance ground-level, i.e. without steps or a step greater than 2 centimeters?"
 
-msgid "L'entrée se fait de plain-pied, c'est à dire sans rupture brutale de niveau"
-msgstr "The entrance is on the same level, that is to say, without a sudden break in level"
+msgid "Entrée de plain pied"
+msgstr "Ground-level entrance"
 
 msgid "L'entrée n'est pas de plain-pied et présente une rupture brutale de niveau"
 msgstr "The entrance is not on the same ground-level and presents a brutal break in level"
@@ -1669,11 +1660,20 @@ msgstr "No stairs"
 msgid "Repérage des marches"
 msgstr "Identification of the steps"
 
+msgid "Présence de nez de marche contrastés, d'une bande d'éveil à la vigilance en haut de l'escalier et/ou de première et dernière contremarches contrastées"
+msgstr "Presence of contrasting stair nosings, a warning strip at the top of the stairs and/or contrasting first and last risers"
+
+msgid "Pas de nez de marche contrasté, de bande d'éveil à la vigilance en haut de l'escalier ni de première et dernière contremarches contrastées"
+msgstr "No contrasting stair nosing, warning strips at the top of the stairs or contrasting first and last risers"
+
+msgid "L'escalier est équipé d'une ou plusieurs main-courantes"
+msgstr "The staircase is equipped with one or more handrails"
+
+msgid "L'escalier n'est pas équipé de main-courante"
+msgstr "The staircase is not equipped with a handrail"
+
 msgid "Existe-t-il un dispositif pour permettre à quelqu'un signaler sa présence à l'entrée&nbsp;?"
 msgstr "Is there a device to allow someone to signal their presence at the entrance?"
-
-msgid "Présence d'un dispositif comme une sonnette pour signaler sa présence"
-msgstr "Presence of a device such as a bell to signal its presence"
 
 msgid "Pas de dispositif comme une sonnette pour signaler sa présence"
 msgstr "No device such as a doorbell to signal its presence"
@@ -1693,17 +1693,14 @@ msgstr "Audio location signal at the entrance"
 msgid "L'entrée est-elle équipée d'une balise sonore facilitant son repérage par une personne aveugle ou malvoyante&nbsp;?"
 msgstr "Is the entrance equipped with an audio location signal to facilitate its location by a blind or visually impaired person?"
 
-msgid "Présence d'une balise sonore facilitant son repérage par une personne aveugle ou malvoyante"
-msgstr "Presence of an audio location signal to facilitate its location by a blind or visually impaired person"
-
 msgid "Pas de balise sonore facilitant son repérage par une personne aveugle ou malvoyante"
 msgstr "No audio location signal to facilitate its location by a blind or visually impaired person"
 
 msgid "Présence ou possibilité d'une aide humaine au déplacement"
 msgstr "Presence or possibility of a human assistance to move"
 
-msgid "Possibilité d'une aide humaine au déplacement"
-msgstr "Possibility of human assistance to move"
+msgid "Aide humaine possible"
+msgstr "Human help possible"
 
 msgid "Pas de possibilité d'aide humaine au déplacement"
 msgstr "No possibility of human assistance to move"
@@ -1714,14 +1711,17 @@ msgstr "Width of the door"
 msgid "Si la largeur n'est pas précisément connue, indiquer une valeur minimum. Exemple&nbsp;: la largeur se situe entre 90 et 100 centimètres&nbsp;; indiquer 90."
 msgstr "If the width is not precisely known, indicate a minimum value. Example: the width is between 90 and 100 centimeters; indicate 90."
 
-msgid "Largeur minimale de la porte d'entrée"
-msgstr "Minimum width of the entrance door"
+msgid "Largeur d'au moins 80 cm"
+msgstr ""
+
+msgid "Largeur inférieure à 80 cm"
+msgstr ""
 
 msgid "Existe-t-il une entrée secondaire spécifique dédiée aux personnes à mobilité réduite&nbsp;?"
 msgstr "Is there a specific secondary entrance for people with reduced mobility?"
 
-msgid "Présence d'une entrée secondaire spécifique dédiée aux personnes à mobilité réduite"
-msgstr "Presence of a specific secondary entrance dedicated to people with reduced mobility"
+msgid "Présence d'une entrée PMR"
+msgstr ""
 
 msgid "Pas d'entrée secondaire spécifique dédiée aux personnes à mobilité réduite"
 msgstr "No specific secondary entrance for people with reduced mobility"
@@ -1738,11 +1738,11 @@ msgstr "Visibility of the reception area"
 msgid "La zone d'accueil (guichet d'accueil, caisse, secrétariat, etc) est-elle visible depuis l'entrée du bâtiment&nbsp;?"
 msgstr "Is the reception area (reception desk, cashier, secretary, etc.) visible from the building entrance?"
 
-msgid "La zone d'accueil (guichet d'accueil, caisse, secrétariat, etc) est visible depuis l'entrée du bâtiment"
-msgstr "The reception area (reception desk, cash desk, secretariat, etc.) is visible from the building entrance"
+msgid "Accueil à proximité direct de l'entrée"
+msgstr ""
 
-msgid "La zone d'accueil (guichet d'accueil, caisse, secrétariat, etc) n'est pas visible depuis l'entrée du bâtiment"
-msgstr "The reception area (reception desk, cash desk, secretariat, etc.) is not visible from the building entrance"
+msgid "Accueil éloigné de l'entrée"
+msgstr ""
 
 msgid "Chemin entre l'entrée principale du bâtiment et l'accueil de l'établissement"
 msgstr "Pathway between the main entrance of the building and the reception of the facility"
@@ -1750,17 +1750,29 @@ msgstr "Pathway between the main entrance of the building and the reception of t
 msgid "Une fois l'entrée du bâtiment passée, le chemin jusqu'à l'accueil de l'établissement est t-il de plain-pied, c'est-à-dire sans marche ni ressaut supérieur à 2 centimètres&nbsp;? (attention, plain-pied ne signifie pas plat mais sans rupture brutale de niveau)"
 msgstr "Once you have entered the building, is the path to the reception of the facility ground-level, i.e. without any step or step greater than 2 centimeters? (attention, level does not mean flat, but without a sudden break in level)"
 
+msgid "Chemin vers l'accueil de plain pied"
+msgstr ""
+
+msgid "Présence d'un ascenseur ou un élévateur"
+msgstr "Presence of an elevator"
+
 msgid "Repérage des marches ou de l'escalier"
 msgstr "Identification of the steps or staircase"
 
 msgid "Nez de marche contrastés, bande d'éveil à la vigilance en haut de l'escalier et/ou première et dernière contremarches contrastées"
 msgstr "Contrasting stair nosings, warning strips at the top of the stairs and/or contrasting first and last risers"
 
+msgid "Pas de rampe fixe ou amovible"
+msgstr "No stationary or removable ramps"
+
 msgid "Existe-t-il un ou plusieurs rétrécissements (inférieur à 90 centimètres) du chemin emprunté par le public pour atteindre la zone d'accueil&nbsp;?"
 msgstr "Are there one or more narrowings (less than 90 centimeters) in the path used by the public to reach the reception area?"
 
-msgid "Présence d'un ou plusieurs rétrécissements inférieurs à 90 centimètres du chemin pour atteindre la zone d'accueil"
-msgstr "Presence of one or more narrowings of less than 90 centimeters in the path to the reception area"
+msgid "Présence de rétrécissement inférieur à 90 cm pour atteindre l'accueil"
+msgstr ""
+
+msgid "Largeur minimale de 90 cm sur toute la circulation menant à l'accueil"
+msgstr ""
 
 msgid "Nombre de chambres accessibles à une personne en fauteuil roulant"
 msgstr "Number of rooms accessible to a person in a wheelchair"
@@ -1768,8 +1780,8 @@ msgstr "Number of rooms accessible to a person in a wheelchair"
 msgid "Nombre de chambres accessibles à une personne en fauteuil roulant : espace et aménagement suffisant pour permettre à une personne en fauteuil de circuler dans la chambre, atteindre le lit et tourner (espace de rotation d’au moins 150 cm de diamètre)"
 msgstr "Number of rooms accessible to a person in a wheelchair: sufficient space and layout to allow a person in a wheelchair to move around the room, reach the bed and turn (turning space at least 150 cm in diameter)"
 
-msgid "Aucune chambre accessible à une personne en fauteuil roulant"
-msgstr "No wheelchair accessible rooms"
+msgid "Pas de chambre accessible"
+msgstr ""
 
 msgid "Douche accessible"
 msgstr "Accessible shower"
@@ -1777,20 +1789,20 @@ msgstr "Accessible shower"
 msgid "La douche est-elle à l'italienne ou équipée d'un bac extra plat (hauteur inférieure à 2 cm)&nbsp;?"
 msgstr "Is the shower Italian or equipped with an extra-flat tray (height less than 2 cm)?"
 
-msgid "La douche est à l'italienne ou équipée d'un bac extra plat"
-msgstr "The shower is Italian or equipped with an extra flat tray"
+msgid "Douche à l'italienne (bac plat)"
+msgstr ""
 
-msgid "La douche n'est pas à l'italienne ni équipée d'un bac extra plat"
-msgstr "The shower is not Italian style and not equipped with an extra flat tray"
+msgid "Douche classique, avec ressaut ou marche"
+msgstr ""
 
 msgid "La douche est-elle équipée d'un siège de douche normé et d'une largeur minimum de 40 cm&nbsp;?"
 msgstr "Is the shower equipped with a standard shower seat with a minimum width of 40 cm?"
 
-msgid "La douche est équipée d'un siège de douche"
-msgstr "The shower is equipped with a shower seat"
+msgid "Avec siège de douche"
+msgstr ""
 
-msgid "La douche n'est pas équipée d'un siège de douche"
-msgstr "The shower is not equipped with a shower seat"
+msgid "Sans siège de douche"
+msgstr ""
 
 msgid "Douche sécurisée"
 msgstr "Secure shower"
@@ -1798,11 +1810,11 @@ msgstr "Secure shower"
 msgid "La douche est-elle équipée d'une barre d'appui horizontale permettant le transfert depuis un fauteuil vers le siège de douche&nbsp;?"
 msgstr "Is the shower equipped with a horizontal grab bar that allows for transfer from a chair to the shower seat?"
 
-msgid "La douche est équipée d'une barre d'appui horizontale"
-msgstr "The shower is equipped with a horizontal grab bar"
+msgid "Barre d'appui"
+msgstr ""
 
-msgid "La douche n'est pas équipée d'une barre d'appui horizontale"
-msgstr "The shower is not equipped with a horizontal grab bar"
+msgid "Sans barre d'appui"
+msgstr ""
 
 msgid "Toilette sécurisé"
 msgstr "Secure toilet"
@@ -1810,11 +1822,8 @@ msgstr "Secure toilet"
 msgid "Le toilette est-il équipé d'une barre d'appui horizontale&nbsp;?"
 msgstr "Is the toilet equipped with a horizontal grab bar?"
 
-msgid "Le toilette est équipé d'une barre d'appui horizontale"
-msgstr "The toilet is equipped with a horizontal grab bar"
-
-msgid "Le toilette n'est pas équipé d'une barre d'appui horizontale"
-msgstr "The toilet is not equipped with a horizontal grab bar"
+msgid "Avec Barre d'appui"
+msgstr ""
 
 msgid "Toilette accessible"
 msgstr "Accessible toilet"
@@ -1822,11 +1831,11 @@ msgstr "Accessible toilet"
 msgid "Le toilette dispose-t-il d'un espace d'usage (80 cm x 130 cm) à côté de la cuvette&nbsp;?"
 msgstr "Does the toilet have a usage space (80 cm x 130 cm) next to the toilet bowl?"
 
-msgid "Le toilette dispose d'un espace d'usage à côté de la cuvette"
-msgstr "The toilet has a usage area next to the toilet bowl"
+msgid "Avec espace d'usage"
+msgstr ""
 
-msgid "Le toilette ne dispose pas d'un espace d'usage à côté de la cuvette"
-msgstr "The toilet does not have a usage area next to the bowl"
+msgid "Sans espace d'usage"
+msgstr ""
 
 msgid "Visibilité des numéros de chambres"
 msgstr "Visibility of room numbers"
@@ -1834,11 +1843,11 @@ msgstr "Visibility of room numbers"
 msgid "Les numéros de chambres sont-ils bien repérables et en relief (très contrastés, positionnés à hauteur des yeux, soit 160 cm, au milieu de la porte ou au-dessus de la poignée, et relief d’au moins 2 cm d’épaisseur) ?"
 msgstr "Are the room numbers clearly visible and in relief (high contrast, positioned at eye level, i.e. 160 cm, in the middle of the door or above the handle, and in relief at least 2 cm thick)?"
 
-msgid "Les numéros de chambres sont repérables et en relief"
-msgstr "The room numbers are clearly marked and embossed"
+msgid "Numéros de chambre en relief"
+msgstr ""
 
-msgid "Les numéros de chambres ne sont pas repérables et en relief"
-msgstr "The room numbers are not recognizable and embossed"
+msgid "Numéros de chambre sans relief"
+msgstr ""
 
 msgid "Equipement d'alerte adapté"
 msgstr "Adapted warning equipment"
@@ -1846,11 +1855,11 @@ msgstr "Adapted warning equipment"
 msgid "L'établissement dispose-t-il d'un ou plusieurs équipements d'alerte par flash lumineux ou vibration&nbsp;?"
 msgstr "Does the facility have one or more flashing light or vibrating alarm systems?"
 
-msgid "L'établissement dispose d'un ou plusieurs équipements d'alerte par flash lumineux ou vibration"
-msgstr "The facility has one or more flashing light or vibrating alarm systems"
+msgid "Equipement d'alerte par flash lumineux ou vibration"
+msgstr ""
 
-msgid "L'établissement ne dispose pas d'équipement d'alerte par flash lumineux ou vibration"
-msgstr "The facility does not have any flashing light or vibration alert equipment"
+msgid "Pas d'équipement d'alerte par flash lumineux ou vibration"
+msgstr ""
 
 msgid "Accompagnement spécifique"
 msgstr "Specific accompaniment"
@@ -1858,11 +1867,8 @@ msgstr "Specific accompaniment"
 msgid "Est-il proposé un accompagnement personnalisé pour présenter la chambre à un client en situation de handicap, notamment aveugle ou malvoyant&nbsp;?"
 msgstr "Is there a personalized accompaniment to introduce the room to a client with a disability, particularly the blind or visually impaired?"
 
-msgid "Il est proposé un accompagnement personnalisé pour présenter la chambre à un client en situation de handicap, notamment aveugle ou malvoyant"
-msgstr "We offer personalized assistance in presenting the room to a client with a disability, particularly the blind or visually impaired"
-
-msgid "Aucun accompagnement personnalisé pour présenter la chambre à un client en situation de handicap n'est proposé"
-msgstr "No personalized assistance is offered to introduce the room to a client with a disability"
+msgid "Pas de possibilité d'accompagnement personnalisé pour présenter la chambre"
+msgstr ""
 
 msgid "En cas de présence du personnel, est-il formé ou sensibilisé à l'accueil des personnes handicapées&nbsp;?"
 msgstr "If the staff is present, are they trained or aware of how to welcome people with disabilities?"
@@ -1879,8 +1885,8 @@ msgstr "Does the facility offer audiodescription?"
 msgid "L'établissement propose l'audiodescription"
 msgstr "The facility offers audio description"
 
-msgid "L'établissement ne propose pas l’audiodescription"
-msgstr "The facility does not offer audio description"
+msgid "Pas d'audiodescription"
+msgstr ""
 
 msgid "Type d'équipements pour l'audiodescription"
 msgstr "Type of equipment for audio description"
@@ -1894,11 +1900,11 @@ msgstr "Presence of hearing and communication aids"
 msgid "L'accueil est-il équipé de produits ou prestations dédiés aux personnes sourdes ou malentendantes&nbsp?"
 msgstr "Is the reception area equipped with products or services dedicated to the deaf or hard of hearing?"
 
-msgid "Présence de produits ou prestations dédiés aux personnes sourdes ou malentendantes"
-msgstr "Presence of products or services dedicated to deaf or hard of hearing people"
+msgid "Présence d'équipement d'aide à l'audition"
+msgstr ""
 
-msgid "Pas de produits ou prestations dédiés aux personnes sourdes ou malentendantes"
-msgstr "No products or services dedicated to the deaf or hard of hearing"
+msgid "Pas d'équipement d'aide à l'audition"
+msgstr ""
 
 msgid "Liste des équipements d'aide à l'audition et à la communication"
 msgstr "List of hearing and communication aids"
@@ -1915,8 +1921,8 @@ msgstr "Are there any sanitary facilities available to the public?"
 msgid "Des sanitaires sont mis à disposition dans l'établissement"
 msgstr "Sanitary facilities are available in the facility"
 
-msgid "Pas de sanitaires mis à disposition dans l'établissement"
-msgstr "No sanitary facilities provided in the facility"
+msgid "Absence de toilettes"
+msgstr ""
 
 msgid "Sanitaires adaptés"
 msgstr "Adapted sanitary facilities"
@@ -1967,8 +1973,8 @@ msgstr "Internet address where the register can be consulted"
 msgid "L'établissement est-il déclaré conforme ? (réservé à l'administration)"
 msgstr "Is the facility declared compliant (for administration use only)"
 
-msgid "L'établissement a été déclaré conforme à la réglementation"
-msgstr "The facility has been declared compliant with the regulations"
+msgid "Déclaré conforme à la réglementation"
+msgstr "Declared compliant with the regulations"
 
 msgid "l'établissement n'a pas été déclaré conforme à la réglementation auprès de l'administration"
 msgstr "the facility has not been declared to the administration as compliant with the regulations"
@@ -2048,9 +2054,6 @@ msgstr "Path made accessible (%s)"
 
 msgid "Difficulté sur le chemin d'accès"
 msgstr "Difficulty on the access road"
-
-msgid "Entrée de plain pied"
-msgstr "Ground-level entrance"
 
 msgid "Entrée de plain pied mais étroite"
 msgstr "Single level but narrow entrance"
@@ -3593,6 +3596,98 @@ msgstr "Business developer"
 
 msgid "Coach Startup d'État"
 msgstr "Startup Coach"
+
+msgid "Hébergement"
+msgstr ""
+
+msgid "Au moins une chambre accessible à une personne en fauteuil roulant"
+msgstr ""
+
+#, python-format
+msgid "%(nb)s chambres accessibles à une personne en fauteuil roulant"
+msgstr ""
+
+#, python-format
+msgid "%(plain_pied_text)s %(siege)s et %(appui)s"
+msgstr ""
+
+#, python-format
+msgid "Toilettes %(espace)s et %(appui)s"
+msgstr ""
+
+#, python-format
+msgid "Porte %(type)s %(manoeuvre)s"
+msgstr ""
+
+#, python-format
+msgid "Porte %(type)s"
+msgstr ""
+
+#, python-format
+msgid "Porte %(manoeuvre)s"
+msgstr ""
+
+msgid "pour atteindre l'entrée"
+msgstr ""
+
+msgid "Registre d'accessibilité et conformité"
+msgstr ""
+
+msgid "Registre disponible"
+msgstr ""
+
+msgid "Chemin vers l'entrée"
+msgstr ""
+
+msgid "sur le chemin"
+msgstr ""
+
+#, python-format
+msgid "Présence d'une pente %(difficulte)s de longueur %(longueur)s"
+msgstr ""
+
+#, python-format
+msgid "Présence d'une pente %(difficulte)s"
+msgstr ""
+
+#, python-format
+msgid "Présence d'une pente de longueur %(longueur)s"
+msgstr ""
+
+#, python-format
+msgid "Dévers %(difficulty)s"
+msgstr ""
+
+msgid "Transport et stationnement"
+msgstr ""
+
+msgid "Accueil et équipement"
+msgstr ""
+
+msgid "pour atteindre l'accueil"
+msgstr ""
+
+#, python-format
+msgid "Présence de %(nb)s marches %(sens)s %(extra_context)s"
+msgstr ""
+
+#, python-format
+msgid "Présence de %(nb)s marches %(extra_context)s"
+msgstr ""
+
+#, python-format
+msgid "Présence de marches %(sens)s %(extra_context)s"
+msgstr ""
+
+#, python-format
+msgid "Présence de marches %(extra_context)s"
+msgstr ""
+
+#, python-format
+msgid ""
+"\n"
+"%(reperage_marches)s et %(main_courante)s\n"
+msgstr ""
 
 msgid "Ce bâtiment est labellisé Tourisme et handicap"
 msgstr "This building has been awarded the Tourisme & Handicap label"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -1395,9 +1395,6 @@ msgstr ""
 msgid "Existe-t-il un arrêt de transport en commun à moins de 200 mètres de l'établissement&nbsp;?"
 msgstr ""
 
-msgid "Arrêt de transport en commun à moins de 200 mètres de l'établissement"
-msgstr ""
-
 msgid "Pas d'arrêt de transport en commun à moins de 200 mètres de l'établissement"
 msgstr ""
 
@@ -1416,10 +1413,10 @@ msgstr ""
 msgid "Existe-t-il une ou plusieurs places de stationnement dans l'établissement ou au sein de la parcelle de l'établissement&nbsp;?"
 msgstr ""
 
-msgid "Des places de stationnement sont disponibles au sein de la parcelle de l'établissement"
+msgid "Places de parking au sein de l'établissement"
 msgstr ""
 
-msgid "Pas de place de stationnement disponible au sein de la parcelle de l'établissement"
+msgid "Pas de places de parking au sein de l'établissement "
 msgstr ""
 
 msgid "Stationnements adaptés dans l'établissement"
@@ -1428,7 +1425,7 @@ msgstr ""
 msgid "Existe-t-il une ou plusieurs places de stationnement adaptées dans l'établissement ou au sein de la parcelle de l'établissement&nbsp;?"
 msgstr ""
 
-msgid "Des places de stationnement adaptées sont disponibles au sein de la parcelle de l'établissement"
+msgid "Places de parking au sein de l'établissement comprenant des places PMR"
 msgstr ""
 
 msgid "Pas de place de stationnement disponible adaptée au sein de la parcelle de l'établissement"
@@ -1440,10 +1437,10 @@ msgstr ""
 msgid "Existe-t-il une ou plusieurs places de stationnement en voirie ou en parking à moins de 200 mètres de l'établissement&nbsp;?"
 msgstr ""
 
-msgid "Des places de stationnement sont disponibles à moins de 200 mètres de l'établissement"
+msgid "Places de parking à proximité"
 msgstr ""
 
-msgid "Pas de place de stationnement disponible à moins de 200 mètres de l'établissement"
+msgid "Pas de places de parking à proximité"
 msgstr ""
 
 msgid "Stationnements adaptés à proximité de l'établissement"
@@ -1452,7 +1449,7 @@ msgstr ""
 msgid "Existe-t-il une ou plusieurs places de stationnement adaptées en voirie ou en parking à moins de 200 mètres de l'établissement&nbsp;?"
 msgstr ""
 
-msgid "Des places de stationnement adaptées sont disponibles à moins de 200 mètres de l'établissement"
+msgid "Places de parking à proximité comprenant des places PMR"
 msgstr ""
 
 msgid "Pas de place de stationnement disponible adaptée à moins de 200 mètres de l'établissement"
@@ -1461,7 +1458,7 @@ msgstr ""
 msgid "Y-a-t-il un chemin extérieur entre le trottoir et l'entrée principale du bâtiment (exemple&nbsp;: une cour)&nbsp;?"
 msgstr ""
 
-msgid "L'accès à l'entrée depuis la voirie se fait par un chemin extérieur"
+msgid "Présence d'un chemin sur la parcelle de l'établissement qui mène à l'entrée"
 msgstr ""
 
 msgid "Pas de chemin extérieur entre le trottoir et l'entrée principale du bâtiment"
@@ -1473,10 +1470,10 @@ msgstr ""
 msgid "Le revêtement du chemin extérieur (entre le trottoir et l'entrée de l'établissement) est-il stable (sol roulable, absence de pavés ou de gravillons, pas de terre ni d'herbe, etc.)&nbsp;?"
 msgstr ""
 
-msgid "Le revêtement est stable (absence de pavés, gravillons, terre, herbe, sable, ou toute surface non stabilisée)"
+msgid "Revêtement stable"
 msgstr ""
 
-msgid "Le revêtement n'est pas stable (pavés, gravillons, terre, herbe, sable, ou toute surface non stabilisée)"
+msgid "Revêtement meuble"
 msgstr ""
 
 msgid "Chemin extérieur de plain-pied"
@@ -1492,9 +1489,6 @@ msgid "L'accès à cet espace n'est pas de plain-pied et présente une rupture b
 msgstr ""
 
 msgid "Existe-t-il un ascenseur ou un élévateur&nbsp;?"
-msgstr ""
-
-msgid "Présence d'un ascenseur ou un élévateur"
 msgstr ""
 
 msgid "Pas d'ascenseur ou d'élévateur"
@@ -1524,19 +1518,19 @@ msgstr ""
 msgid "L'escalier est-il sécurisé&nbsp;: nez de marche contrastés, bande d'éveil à la vigilance en haut de l'escalier, première et dernière contremarches contrastées&nbsp;?"
 msgstr ""
 
-msgid "Présence de nez de marche contrastés, d'une bande d'éveil à la vigilance en haut de l'escalier et/ou de première et dernière contremarches contrastées"
+msgid "Escalier sécurisé"
 msgstr ""
 
-msgid "Pas de nez de marche contrasté, de bande d'éveil à la vigilance en haut de l'escalier ni de première et dernière contremarches contrastées"
+msgid "Escalier non sécurisé"
 msgstr ""
 
 msgid "L'escalier est-il équipé d'une ou plusieurs main-courantes&nbsp;?"
 msgstr ""
 
-msgid "L'escalier est équipé d'une ou plusieurs main-courantes"
+msgid "Équipé d'une ou plusieurs mains courantes"
 msgstr ""
 
-msgid "L'escalier n'est pas équipé de main-courante"
+msgid "Non équipé de main courante."
 msgstr ""
 
 msgid "S'il existe une rampe ayant une pente douce, est-elle fixe ou amovible&nbsp;?"
@@ -1545,7 +1539,7 @@ msgstr ""
 msgid "Présence d'une rampe fixe ou amovible"
 msgstr ""
 
-msgid "Pas de rampe fixe ou amovible"
+msgid "Pas de rampe"
 msgstr ""
 
 msgid "Pente"
@@ -1572,7 +1566,7 @@ msgstr ""
 msgid "Dévers ou inclinaison transversale du chemin"
 msgstr ""
 
-msgid "Pas de dévers ou d'inclinaison transversale du chemin"
+msgid "Pas de dévers"
 msgstr ""
 
 msgid "Présence d'une bande de guidage au sol facilitant le déplacement d'une personne aveugle ou malvoyante"
@@ -1587,19 +1581,19 @@ msgstr ""
 msgid "Existe-t-il un ou plusieurs rétrécissements (inférieur à 90 centimètres) du chemin emprunté par le public pour atteindre l'entrée&nbsp;?"
 msgstr ""
 
-msgid "Un ou plusieurs rétrécissements inférieurs à 90 centimètres du chemin pour atteindre la zone d'accueil"
+msgid "Présence de rétrécissement inférieur à 90 cm sur le chemin"
 msgstr ""
 
-msgid "Pas de rétrécissement inférieur à 90 centimètres du chemin pour atteindre la zone d'accueil"
+msgid "Largeur minimale de 90 cm sur tout le chemin"
 msgstr ""
 
 msgid "Y a-t-il des éléments facilitant le repérage de l'entrée de l'établissement (numéro de rue à proximité, enseigne, végétaux, éléments architecturaux contrastés, etc)&nbsp;?"
 msgstr ""
 
-msgid "L'entrée de l'établissement est facilement repérable"
+msgid "Entrée bien visible"
 msgstr ""
 
-msgid "Pas d'éléments facilitant le repérage de l'entrée de l'établissement (numéro de rue à proximité, enseigne, végétaux, éléments architecturaux contrastés, etc)"
+msgid "L'entrée n'est pas bien visible"
 msgstr ""
 
 msgid "Y a-t-il une porte ?"
@@ -1609,9 +1603,6 @@ msgid "Y a-t-il une porte à l'entrée de l'établissement&nbsp;?"
 msgstr ""
 
 msgid "Présence d'une porte à l'entrée de l'établissement"
-msgstr ""
-
-msgid "Pas de porte à l'entrée de l'établissement"
 msgstr ""
 
 msgid "Manoeuvre de la porte"
@@ -1629,7 +1620,7 @@ msgstr ""
 msgid "La porte d'entrée est-elle vitrée&nbsp;?"
 msgstr ""
 
-msgid "La porte d'entrée est vitrée"
+msgid "Porte vitrée"
 msgstr ""
 
 msgid "La porte d'entrée n'est pas vitrée"
@@ -1641,16 +1632,16 @@ msgstr ""
 msgid "Y a-t-il des éléments contrastés (autocollants, éléments de menuiserie ou autres) permettant de repérer la porte vitrée&nbsp;?"
 msgstr ""
 
-msgid "Des éléments contrastés permettent de visualiser les parties vitrées de l'entrée"
+msgid "Avec éléments contrastés sur la partie vitrée"
 msgstr ""
 
-msgid "Pas d'éléments contrastés permettant de visualiser les parties vitrées de l'entrée"
+msgid "Sans éléments contrastés sur la partie vitrée"
 msgstr ""
 
 msgid "L'entrée est-elle de plain-pied, c'est-à-dire sans marche ni ressaut supérieur à 2 centimètres&nbsp;?"
 msgstr ""
 
-msgid "L'entrée se fait de plain-pied, c'est à dire sans rupture brutale de niveau"
+msgid "Entrée de plain pied"
 msgstr ""
 
 msgid "L'entrée n'est pas de plain-pied et présente une rupture brutale de niveau"
@@ -1665,10 +1656,19 @@ msgstr ""
 msgid "Repérage des marches"
 msgstr ""
 
-msgid "Existe-t-il un dispositif pour permettre à quelqu'un signaler sa présence à l'entrée&nbsp;?"
+msgid "Présence de nez de marche contrastés, d'une bande d'éveil à la vigilance en haut de l'escalier et/ou de première et dernière contremarches contrastées"
 msgstr ""
 
-msgid "Présence d'un dispositif comme une sonnette pour signaler sa présence"
+msgid "Pas de nez de marche contrasté, de bande d'éveil à la vigilance en haut de l'escalier ni de première et dernière contremarches contrastées"
+msgstr ""
+
+msgid "L'escalier est équipé d'une ou plusieurs main-courantes"
+msgstr ""
+
+msgid "L'escalier n'est pas équipé de main-courante"
+msgstr ""
+
+msgid "Existe-t-il un dispositif pour permettre à quelqu'un signaler sa présence à l'entrée&nbsp;?"
 msgstr ""
 
 msgid "Pas de dispositif comme une sonnette pour signaler sa présence"
@@ -1689,16 +1689,13 @@ msgstr ""
 msgid "L'entrée est-elle équipée d'une balise sonore facilitant son repérage par une personne aveugle ou malvoyante&nbsp;?"
 msgstr ""
 
-msgid "Présence d'une balise sonore facilitant son repérage par une personne aveugle ou malvoyante"
-msgstr ""
-
 msgid "Pas de balise sonore facilitant son repérage par une personne aveugle ou malvoyante"
 msgstr ""
 
 msgid "Présence ou possibilité d'une aide humaine au déplacement"
 msgstr ""
 
-msgid "Possibilité d'une aide humaine au déplacement"
+msgid "Aide humaine possible"
 msgstr ""
 
 msgid "Pas de possibilité d'aide humaine au déplacement"
@@ -1710,13 +1707,16 @@ msgstr ""
 msgid "Si la largeur n'est pas précisément connue, indiquer une valeur minimum. Exemple&nbsp;: la largeur se situe entre 90 et 100 centimètres&nbsp;; indiquer 90."
 msgstr ""
 
-msgid "Largeur minimale de la porte d'entrée"
+msgid "Largeur d'au moins 80 cm"
+msgstr ""
+
+msgid "Largeur inférieure à 80 cm"
 msgstr ""
 
 msgid "Existe-t-il une entrée secondaire spécifique dédiée aux personnes à mobilité réduite&nbsp;?"
 msgstr ""
 
-msgid "Présence d'une entrée secondaire spécifique dédiée aux personnes à mobilité réduite"
+msgid "Présence d'une entrée PMR"
 msgstr ""
 
 msgid "Pas d'entrée secondaire spécifique dédiée aux personnes à mobilité réduite"
@@ -1734,10 +1734,10 @@ msgstr ""
 msgid "La zone d'accueil (guichet d'accueil, caisse, secrétariat, etc) est-elle visible depuis l'entrée du bâtiment&nbsp;?"
 msgstr ""
 
-msgid "La zone d'accueil (guichet d'accueil, caisse, secrétariat, etc) est visible depuis l'entrée du bâtiment"
+msgid "Accueil à proximité direct de l'entrée"
 msgstr ""
 
-msgid "La zone d'accueil (guichet d'accueil, caisse, secrétariat, etc) n'est pas visible depuis l'entrée du bâtiment"
+msgid "Accueil éloigné de l'entrée"
 msgstr ""
 
 msgid "Chemin entre l'entrée principale du bâtiment et l'accueil de l'établissement"
@@ -1746,16 +1746,28 @@ msgstr ""
 msgid "Une fois l'entrée du bâtiment passée, le chemin jusqu'à l'accueil de l'établissement est t-il de plain-pied, c'est-à-dire sans marche ni ressaut supérieur à 2 centimètres&nbsp;? (attention, plain-pied ne signifie pas plat mais sans rupture brutale de niveau)"
 msgstr ""
 
+msgid "Chemin vers l'accueil de plain pied"
+msgstr ""
+
+msgid "Présence d'un ascenseur ou un élévateur"
+msgstr ""
+
 msgid "Repérage des marches ou de l'escalier"
 msgstr ""
 
 msgid "Nez de marche contrastés, bande d'éveil à la vigilance en haut de l'escalier et/ou première et dernière contremarches contrastées"
 msgstr ""
 
+msgid "Pas de rampe fixe ou amovible"
+msgstr ""
+
 msgid "Existe-t-il un ou plusieurs rétrécissements (inférieur à 90 centimètres) du chemin emprunté par le public pour atteindre la zone d'accueil&nbsp;?"
 msgstr ""
 
-msgid "Présence d'un ou plusieurs rétrécissements inférieurs à 90 centimètres du chemin pour atteindre la zone d'accueil"
+msgid "Présence de rétrécissement inférieur à 90 cm pour atteindre l'accueil"
+msgstr ""
+
+msgid "Largeur minimale de 90 cm sur toute la circulation menant à l'accueil"
 msgstr ""
 
 msgid "Nombre de chambres accessibles à une personne en fauteuil roulant"
@@ -1764,7 +1776,7 @@ msgstr ""
 msgid "Nombre de chambres accessibles à une personne en fauteuil roulant : espace et aménagement suffisant pour permettre à une personne en fauteuil de circuler dans la chambre, atteindre le lit et tourner (espace de rotation d’au moins 150 cm de diamètre)"
 msgstr ""
 
-msgid "Aucune chambre accessible à une personne en fauteuil roulant"
+msgid "Pas de chambre accessible"
 msgstr ""
 
 msgid "Douche accessible"
@@ -1773,19 +1785,19 @@ msgstr ""
 msgid "La douche est-elle à l'italienne ou équipée d'un bac extra plat (hauteur inférieure à 2 cm)&nbsp;?"
 msgstr ""
 
-msgid "La douche est à l'italienne ou équipée d'un bac extra plat"
+msgid "Douche à l'italienne (bac plat)"
 msgstr ""
 
-msgid "La douche n'est pas à l'italienne ni équipée d'un bac extra plat"
+msgid "Douche classique, avec ressaut ou marche"
 msgstr ""
 
 msgid "La douche est-elle équipée d'un siège de douche normé et d'une largeur minimum de 40 cm&nbsp;?"
 msgstr ""
 
-msgid "La douche est équipée d'un siège de douche"
+msgid "Avec siège de douche"
 msgstr ""
 
-msgid "La douche n'est pas équipée d'un siège de douche"
+msgid "Sans siège de douche"
 msgstr ""
 
 msgid "Douche sécurisée"
@@ -1794,10 +1806,10 @@ msgstr ""
 msgid "La douche est-elle équipée d'une barre d'appui horizontale permettant le transfert depuis un fauteuil vers le siège de douche&nbsp;?"
 msgstr ""
 
-msgid "La douche est équipée d'une barre d'appui horizontale"
+msgid "Barre d'appui"
 msgstr ""
 
-msgid "La douche n'est pas équipée d'une barre d'appui horizontale"
+msgid "Sans barre d'appui"
 msgstr ""
 
 msgid "Toilette sécurisé"
@@ -1806,10 +1818,7 @@ msgstr ""
 msgid "Le toilette est-il équipé d'une barre d'appui horizontale&nbsp;?"
 msgstr ""
 
-msgid "Le toilette est équipé d'une barre d'appui horizontale"
-msgstr ""
-
-msgid "Le toilette n'est pas équipé d'une barre d'appui horizontale"
+msgid "Avec Barre d'appui"
 msgstr ""
 
 msgid "Toilette accessible"
@@ -1818,10 +1827,10 @@ msgstr ""
 msgid "Le toilette dispose-t-il d'un espace d'usage (80 cm x 130 cm) à côté de la cuvette&nbsp;?"
 msgstr ""
 
-msgid "Le toilette dispose d'un espace d'usage à côté de la cuvette"
+msgid "Avec espace d'usage"
 msgstr ""
 
-msgid "Le toilette ne dispose pas d'un espace d'usage à côté de la cuvette"
+msgid "Sans espace d'usage"
 msgstr ""
 
 msgid "Visibilité des numéros de chambres"
@@ -1830,10 +1839,10 @@ msgstr ""
 msgid "Les numéros de chambres sont-ils bien repérables et en relief (très contrastés, positionnés à hauteur des yeux, soit 160 cm, au milieu de la porte ou au-dessus de la poignée, et relief d’au moins 2 cm d’épaisseur) ?"
 msgstr ""
 
-msgid "Les numéros de chambres sont repérables et en relief"
+msgid "Numéros de chambre en relief"
 msgstr ""
 
-msgid "Les numéros de chambres ne sont pas repérables et en relief"
+msgid "Numéros de chambre sans relief"
 msgstr ""
 
 msgid "Equipement d'alerte adapté"
@@ -1842,10 +1851,10 @@ msgstr ""
 msgid "L'établissement dispose-t-il d'un ou plusieurs équipements d'alerte par flash lumineux ou vibration&nbsp;?"
 msgstr ""
 
-msgid "L'établissement dispose d'un ou plusieurs équipements d'alerte par flash lumineux ou vibration"
+msgid "Equipement d'alerte par flash lumineux ou vibration"
 msgstr ""
 
-msgid "L'établissement ne dispose pas d'équipement d'alerte par flash lumineux ou vibration"
+msgid "Pas d'équipement d'alerte par flash lumineux ou vibration"
 msgstr ""
 
 msgid "Accompagnement spécifique"
@@ -1854,10 +1863,7 @@ msgstr ""
 msgid "Est-il proposé un accompagnement personnalisé pour présenter la chambre à un client en situation de handicap, notamment aveugle ou malvoyant&nbsp;?"
 msgstr ""
 
-msgid "Il est proposé un accompagnement personnalisé pour présenter la chambre à un client en situation de handicap, notamment aveugle ou malvoyant"
-msgstr ""
-
-msgid "Aucun accompagnement personnalisé pour présenter la chambre à un client en situation de handicap n'est proposé"
+msgid "Pas de possibilité d'accompagnement personnalisé pour présenter la chambre"
 msgstr ""
 
 msgid "En cas de présence du personnel, est-il formé ou sensibilisé à l'accueil des personnes handicapées&nbsp;?"
@@ -1875,7 +1881,7 @@ msgstr ""
 msgid "L'établissement propose l'audiodescription"
 msgstr ""
 
-msgid "L'établissement ne propose pas l’audiodescription"
+msgid "Pas d'audiodescription"
 msgstr ""
 
 msgid "Type d'équipements pour l'audiodescription"
@@ -1890,10 +1896,10 @@ msgstr ""
 msgid "L'accueil est-il équipé de produits ou prestations dédiés aux personnes sourdes ou malentendantes&nbsp?"
 msgstr ""
 
-msgid "Présence de produits ou prestations dédiés aux personnes sourdes ou malentendantes"
+msgid "Présence d'équipement d'aide à l'audition"
 msgstr ""
 
-msgid "Pas de produits ou prestations dédiés aux personnes sourdes ou malentendantes"
+msgid "Pas d'équipement d'aide à l'audition"
 msgstr ""
 
 msgid "Liste des équipements d'aide à l'audition et à la communication"
@@ -1911,7 +1917,7 @@ msgstr ""
 msgid "Des sanitaires sont mis à disposition dans l'établissement"
 msgstr ""
 
-msgid "Pas de sanitaires mis à disposition dans l'établissement"
+msgid "Absence de toilettes"
 msgstr ""
 
 msgid "Sanitaires adaptés"
@@ -1963,7 +1969,7 @@ msgstr ""
 msgid "L'établissement est-il déclaré conforme ? (réservé à l'administration)"
 msgstr ""
 
-msgid "L'établissement a été déclaré conforme à la réglementation"
+msgid "Déclaré conforme à la réglementation"
 msgstr ""
 
 msgid "l'établissement n'a pas été déclaré conforme à la réglementation auprès de l'administration"
@@ -2043,9 +2049,6 @@ msgid "Chemin rendu accessible (%s)"
 msgstr ""
 
 msgid "Difficulté sur le chemin d'accès"
-msgstr ""
-
-msgid "Entrée de plain pied"
 msgstr ""
 
 msgid "Entrée de plain pied mais étroite"
@@ -3439,6 +3442,98 @@ msgid "Chargé de déploiement"
 msgstr ""
 
 msgid "Coach Startup d'État"
+msgstr ""
+
+msgid "Hébergement"
+msgstr ""
+
+msgid "Au moins une chambre accessible à une personne en fauteuil roulant"
+msgstr ""
+
+#, python-format
+msgid "%(nb)s chambres accessibles à une personne en fauteuil roulant"
+msgstr ""
+
+#, python-format
+msgid "%(plain_pied_text)s %(siege)s et %(appui)s"
+msgstr ""
+
+#, python-format
+msgid "Toilettes %(espace)s et %(appui)s"
+msgstr ""
+
+#, python-format
+msgid "Porte %(type)s %(manoeuvre)s"
+msgstr ""
+
+#, python-format
+msgid "Porte %(type)s"
+msgstr ""
+
+#, python-format
+msgid "Porte %(manoeuvre)s"
+msgstr ""
+
+msgid "pour atteindre l'entrée"
+msgstr ""
+
+msgid "Registre d'accessibilité et conformité"
+msgstr ""
+
+msgid "Registre disponible"
+msgstr ""
+
+msgid "Chemin vers l'entrée"
+msgstr ""
+
+msgid "sur le chemin"
+msgstr ""
+
+#, python-format
+msgid "Présence d'une pente %(difficulte)s de longueur %(longueur)s"
+msgstr ""
+
+#, python-format
+msgid "Présence d'une pente %(difficulte)s"
+msgstr ""
+
+#, python-format
+msgid "Présence d'une pente de longueur %(longueur)s"
+msgstr ""
+
+#, python-format
+msgid "Dévers %(difficulty)s"
+msgstr ""
+
+msgid "Transport et stationnement"
+msgstr ""
+
+msgid "Accueil et équipement"
+msgstr ""
+
+msgid "pour atteindre l'accueil"
+msgstr ""
+
+#, python-format
+msgid "Présence de %(nb)s marches %(sens)s %(extra_context)s"
+msgstr ""
+
+#, python-format
+msgid "Présence de %(nb)s marches %(extra_context)s"
+msgstr ""
+
+#, python-format
+msgid "Présence de marches %(sens)s %(extra_context)s"
+msgstr ""
+
+#, python-format
+msgid "Présence de marches %(extra_context)s"
+msgstr ""
+
+#, python-format
+msgid ""
+"\n"
+"%(reperage_marches)s et %(main_courante)s\n"
 msgstr ""
 
 msgid "Ce bâtiment est labellisé Tourisme et handicap"

--- a/templates/erp/includes/access_accommodation.html
+++ b/templates/erp/includes/access_accommodation.html
@@ -1,0 +1,43 @@
+{% load a4a %}
+{% load static %}
+{% load i18n %}
+<h4 class="pt-2 h4">
+    <i aria-hidden="true" class="icon icon-house mr-1 larger-font"></i>{% translate "Hébergement" %}
+</h4>
+<ul>
+    <li>
+        {% if access.accueil_chambre_nombre_accessibles %}
+            {% if access.access.accueil_chambre_nombre_accessibles == 1 %}
+                {% translate "Au moins une chambre accessible à une personne en fauteuil roulant" %}
+            {% else %}
+                {% blocktranslate trimmed with nb=access.accueil_chambre_nombre_accessibles %}
+                    {{ nb }} chambres accessibles à une personne en fauteuil roulant
+                {% endblocktranslate %}
+            {% endif %}
+        {% else %}
+            {{ "accueil_chambre_nombre_accessibles"|negative_text }}
+        {% endif %}
+    </li>
+    {% if access.accueil_chambre_douche_plain_pied or access.accueil_chambre_douche_siege or access.accueil_chambre_douche_barre_appui %}
+        <li>
+            {% access_text "accueil_chambre_douche_plain_pied" access as plain_pied_text %}
+            {% access_text "accueil_chambre_douche_siege" access as siege_text %}
+            {% access_text "accueil_chambre_douche_barre_appui" access as appui_text %}
+            {% blocktranslate trimmed with type=plain_pied_text siege=siege_text|lower appui=appui_text|lower %}
+                {{ plain_pied_text }} {{ siege }} et {{ appui }}
+            {% endblocktranslate %}
+        </li>
+    {% endif %}
+    {% if access.accueil_chambre_sanitaires_barre_appui or access.accueil_chambre_sanitaires_espace_usage %}
+        <li>
+            {% access_text "accueil_chambre_sanitaires_espace_usage" access as espace_text %}
+            {% access_text "accueil_chambre_sanitaires_barre_appui" access as appui_text %}
+            {% blocktranslate trimmed with espace=espace_text|lower appui=appui_text|lower %}
+                Toilettes {{ espace }} et {{ appui }}
+            {% endblocktranslate %}
+        </li>
+    {% endif %}
+    {% render_access_value "accueil_chambre_numero_visible" access %}
+    {% render_access_value "accueil_chambre_equipement_alerte" access %}
+    {% render_access_value "accueil_chambre_accompagnement" access %}
+</ul>

--- a/templates/erp/includes/access_entrance.html
+++ b/templates/erp/includes/access_entrance.html
@@ -1,0 +1,76 @@
+{% load a4a %}
+{% load static %}
+{% load i18n %}
+<h4 class="pt-2 h4">
+    <i aria-hidden="true" class="icon icon-entrance mr-1 larger-font"></i>{% translate "Entrée" %}
+</h4>
+<ul>
+    {% render_access_value "entree_reperage" access %}
+    {% if access.entree_balise_sonore %}<li>{{ "entree_balise_sonore"|positive_text }}</li>{% endif %}
+    {% if not access.entree_porte_presence %}<li>{{ "entree_porte_presence"|negative_text }}</li>{% endif %}
+    {% if access.entree_porte_type %}
+        {% if access.entree_porte_manoeuvre %}
+            <li>
+                {% blocktranslate trimmed with type=access.entree_porte_type manoeuvre=access.entree_porte_manoeuvre %}
+                    Porte {{ type }} {{ manoeuvre }}
+                {% endblocktranslate %}
+            </li>
+        {% else %}
+            <li>
+                {% blocktranslate trimmed with type=access.entree_porte_type %}
+                    Porte {{ type }}
+                {% endblocktranslate %}
+            </li>
+        {% endif %}
+    {% else %}
+        {% if access.entree_porte_manoeuvre %}
+            <li>
+                {% blocktranslate trimmed with manoeuvre=access.entree_porte_manoeuvre %}
+                    Porte {{ manoeuvre }}
+                {% endblocktranslate %}
+            </li>
+        {% endif %}
+    {% endif %}
+    {% if access.entree_largeur_mini >= 80 %}
+        <li>{{ "entree_largeur_mini"|positive_text }}</li>
+    {% else %}
+        <li>{{ "entree_largeur_mini"|negative_text }}</li>
+    {% endif %}
+    <li>
+        {% if access.entree_vitree %}
+            {{ "entree_vitree"|positive_text }} {{ "entree_vitree_vitrophanie"|positive_text|lower }}
+        {% else %}
+            {{ "entree_vitree"|negative_text }}
+        {% endif %}
+    </li>
+    <li>
+        {% if access.entree_plain_pied %}
+            {{ "entree_plain_pied"|positive_text }}
+        {% else %}
+            {% translate "pour atteindre l'entrée" as extra_context %}
+            {% include "erp/includes/access_stairs.html" with steps_direction=access.entree_marches_sens nb_steps=access.entree_marches %}
+        {% endif %}
+    </li>
+    <li>
+        {% include "erp/includes/access_steps.html" with main_courante_data=access.entree_marches_main_courante reperage=access.entree_marches_reperage %}
+    </li>
+    {% render_access_value "entree_marches_rampe" access %}
+    {% if access.cheminement_ext_ascenseur %}<li>{{ "cheminement_ext_ascenseur"|positive_text }}</li>{% endif %}
+    {% if access.entree_aide_humaine %}<li>{{ "entree_aide_humaine"|positive_text }}</li>{% endif %}
+    {% if access.entree_dispositif_appel %}
+        {% if access.entree_dispositif_appel_type %}
+            {% for equipment in access.entree_dispositif_appel_type %}<li>{{ equipment|title }}</li>{% endfor %}
+        {% else %}
+            <li>{{ "entree_dispositif_appel"|positive_text }}</li>
+        {% endif %}
+    {% endif %}
+    {% if access.entree_pmr %}
+        <li>
+            {{ "entree_pmr"|positive_text }}
+            {% if access.entree_pmr_informations %}
+                <br />
+                {{ entree_pmr_informations }}
+            {% endif %}
+        </li>
+    {% endif %}
+</ul>

--- a/templates/erp/includes/access_legal.html
+++ b/templates/erp/includes/access_legal.html
@@ -1,0 +1,14 @@
+{% load a4a %}
+{% load static %}
+{% load i18n %}
+<h4 class="pt-2 h4">
+    <i aria-hidden="true" class="icon icon-paperclip mr-1 larger-font"></i>{% translate "Registre d'accessibilité et conformité" %}
+</h4>
+<ul>
+    {% if access.registre_url %}
+        <li>
+            {% translate "Registre disponible" %} : <a href="{{ access.registre_url }}">{{ access.registre_url }}</a>
+        </li>
+    {% endif %}
+    {% if access.conformite %}<li>{{ "conformite"|positive_text }}</li>{% endif %}
+</ul>

--- a/templates/erp/includes/access_outside_path.html
+++ b/templates/erp/includes/access_outside_path.html
@@ -1,0 +1,59 @@
+{% load a4a %}
+{% load static %}
+{% load i18n %}
+<h4 class="pt-2 h4">
+    <i aria-hidden="true" class="icon icon-road mr-1 larger-font"></i>{% translate "Chemin vers l'entrée" %}
+</h4>
+<ul>
+    {% if access.has_outside_path_and_no_other_data %}<li>{{ "cheminement_ext_presence"|positive_text }}</li>{% endif %}
+    {% if access.cheminement_ext_bande_guidage %}<li>{{ "cheminement_ext_bande_guidage"|positive_text }}</li>{% endif %}
+    {% if access.cheminement_ext_plain_pied %}
+        <li>{{ "cheminement_ext_plain_pied"|positive_text }}</li>
+    {% else %}
+        <li>
+            {% translate "sur le chemin" as extra_context %}
+            {% include "erp/includes/access_stairs.html" with steps_direction=access.cheminement_ext_sens_marches nb_steps=access.cheminement_ext_nombre_marches extra_context=extra_context %}
+        </li>
+    {% endif %}
+    <li>
+        {% include "erp/includes/access_steps.html" with main_courante_data=access.cheminement_ext_main_courante reperage=access.cheminement_ext_reperage_marches %}
+    </li>
+    {% render_access_value "cheminement_ext_rampe" access %}
+    {% if access.cheminement_ext_ascenseur %}<li>{{ "cheminement_ext_ascenseur"|positive_text }}</li>{% endif %}
+    {% render_access_value "cheminement_ext_retrecissement" access %}
+    {% if access.cheminement_ext_pente_presence %}
+        {% if access.cheminement_ext_pente_degre_difficulte %}
+            {% if access.cheminement_ext_pente_longueur %}
+                <li>
+                    {% blocktranslate trimmed with longueur=access.cheminement_ext_pente_longueur difficulte=access.cheminement_ext_pente_degre_difficulte %}
+                        Présence d'une pente {{ difficulte }} de longueur {{ longueur }}
+                    {% endblocktranslate %}
+                </li>
+            {% else %}
+                <li>
+                    {% blocktranslate trimmed with difficulte=access.cheminement_ext_pente_degre_difficulte %}
+                        Présence d'une pente {{ difficulte }}
+                    {% endblocktranslate %}
+                </li>
+            {% endif %}
+        {% else %}
+            <li>
+                {% if access.cheminement_ext_pente_longueur %}
+                    {% blocktranslate trimmed with longueur=access.cheminement_ext_pente_longueur %}
+                        Présence d'une pente de longueur {{ longueur }}
+                    {% endblocktranslate %}
+                </li>
+            {% endif %}
+        {% endif %}
+    {% endif %}
+    <li>
+        {% if access.has_camber %}
+            {% blocktranslate trimmed with difficulty=access.cheminement_ext_devers %}
+                Dévers {{ difficulty }}
+            {% endblocktranslate %}
+        {% else %}
+            {{ "cheminement_ext_devers"|negative_text }}
+        {% endif %}
+    </li>
+    {% render_access_value "cheminement_ext_retrecissement" access %}
+</ul>

--- a/templates/erp/includes/access_parking.html
+++ b/templates/erp/includes/access_parking.html
@@ -1,0 +1,32 @@
+{% load a4a %}
+{% load static %}
+{% load i18n %}
+<h4 class="pt-2 h4">
+    <i aria-hidden="true" class="icon icon-bus mr-1 larger-font"></i>{% translate "Transport et stationnement" %}
+</h4>
+<ul>
+    {% if access.transport_station_presence %}
+        <li>
+            {{ "transport_station_presence"|positive_text }}
+            {% if access.transport_information %}: {{ access.transport_information }}{% endif %}
+        </li>
+    {% endif %}
+    {% if access.stationnement_presence %}
+        {% if access.stationnement_pmr %}
+            <li>{{ "stationnement_pmr"|positive_text }}</li>
+        {% else %}
+            <li>{{ "stationnement_presence"|positive_text }}</li>
+        {% endif %}
+    {% else %}
+        <li>{{ "stationnement_presence"|negative_text }}</li>
+    {% endif %}
+    {% if access.stationnement_ext_presence %}
+        {% if access.stationnement_ext_pmr %}
+            <li>{{ "stationnement_ext_pmr"|positive_text }}</li>
+        {% else %}
+            <li>{{ "stationnement_ext_presence"|positive_text }}</li>
+        {% endif %}
+    {% else %}
+        <li>{{ "stationnement_ext_presence"|negative_text }}</li>
+    {% endif %}
+</ul>

--- a/templates/erp/includes/access_reception.html
+++ b/templates/erp/includes/access_reception.html
@@ -1,0 +1,49 @@
+{% load a4a %}
+{% load static %}
+{% load i18n %}
+<h4 class="pt-2 h4">
+    <i aria-hidden="true" class="icon icon-users mr-1 larger-font"></i>{% translate "Accueil et équipement" %}
+</h4>
+<ul>
+    {% render_access_value "accueil_visibilite" access %}
+    <li>
+        {% if access.accueil_cheminement_plain_pied %}
+            {{ "accueil_cheminement_plain_pied"|positive_text }}
+        {% else %}
+            {% translate "pour atteindre l'accueil" as extra_context %}
+            {% include "erp/includes/access_stairs.html" with steps_direction=access.accueil_cheminement_sens_marches nb_steps=access.accueil_cheminement_nombre_marches extra_context=extra_context %}
+        {% endif %}
+    </li>
+    <li>
+        {% include "erp/includes/access_steps.html" with main_courante_data=access.accueil_cheminement_main_courante reperage=access.accueil_cheminement_reperage_marches %}
+    </li>
+    {% render_access_value "accueil_cheminement_rampe" access %}
+    {% if access.accueil_cheminement_ascenseur %}<li>{{ "accueil_cheminement_ascenseur"|positive_text }}</li>{% endif %}
+    {% render_access_value "accueil_retrecissement" access %}
+    {% if access.accueil_personnels %}<li>{{ access.get_accueil_personnels_display }}</li>{% endif %}
+    {% if access.accueil_audiodescription %}
+        <li>{{ access.get_accueil_audiodescription_display }}</li>
+    {% else %}
+        <li>{{ "accueil_audiodescription_presence"|negative_text }}</li>
+    {% endif %}
+    {% if access.accueil_equipements_malentendants_presence %}
+        {% if access.accueil_equipements_malentendants %}
+            {% for equipment in access.accueil_equipements_malentendants %}<li>{{ equipment|title }}</li>{% endfor %}
+        {% else %}
+            <li>{{ "accueil_equipements_malentendants_presence"|positive_text }}</li>
+        {% endif %}
+    {% else %}
+        <li>{{ "accueil_equipements_malentendants_presence"|negative_text }}</li>
+    {% endif %}
+    <li>
+        {% if access.sanitaires_presence %}
+            {% if access.sanitaires_adaptes %}
+                {% translate "Toilettes PMR" %}
+            {% else %}
+                {% translate "Toilettes classiques" %}
+            {% endif %}
+        {% else %}
+            {{ "sanitaires_presence"|negative_text }}
+        {% endif %}
+    </li>
+</ul>

--- a/templates/erp/includes/access_stairs.html
+++ b/templates/erp/includes/access_stairs.html
@@ -1,0 +1,23 @@
+{% load a4a %}
+{% load i18n %}
+{% if nb_steps %}
+    {% if steps_direction %}
+        {% blocktranslate trimmed with nb=nb_steps sens=steps_direction extra_context=extra_context %}
+            Présence de {{ nb }} marches {{ sens }} {{ extra_context }}
+        {% endblocktranslate %}
+    {% else %}
+        {% blocktranslate trimmed with nb=nb_steps extra_context=extra_context %}
+            Présence de {{ nb }} marches {{ extra_context }}
+        {% endblocktranslate %}
+    {% endif %}
+{% else %}
+    {% if steps_direction %}
+        {% blocktranslate trimmed with sens=steps_direction extra_context=extra_context %}
+            Présence de marches {{ sens }} {{ extra_context }}
+        {% endblocktranslate %}
+    {% else %}
+        {% blocktranslate trimmed with extra_context=extra_context %}
+            Présence de marches {{ extra_context }}
+        {% endblocktranslate %}
+    {% endif %}
+{% endif %}

--- a/templates/erp/includes/access_steps.html
+++ b/templates/erp/includes/access_steps.html
@@ -1,0 +1,23 @@
+{% load a4a %}
+{% load i18n %}
+{% if reperage %}
+    {% if main_courante_data %}
+        {% blocktranslate with reperage_marches="cheminement_ext_reperage_marches"|positive_text main_courante="cheminement_ext_main_courante"|positive_text|lower %}
+{{ reperage_marches }} et {{ main_courante }}
+{% endblocktranslate %}
+    {% else %}
+        {% blocktranslate with reperage_marches="cheminement_ext_reperage_marches"|positive_text main_courante="cheminement_ext_main_courante"|negative_text|lower %}
+{{ reperage_marches }} et {{ main_courante }}
+{% endblocktranslate %}
+    {% endif %}
+{% else %}
+    {% if main_courante_data %}
+        {% blocktranslate with reperage_marches="cheminement_ext_reperage_marches"|negative_text main_courante="cheminement_ext_main_courante"|positive_text|lower %}
+{{ reperage_marches }} et {{ main_courante }}
+{% endblocktranslate %}
+    {% else %}
+        {% blocktranslate with reperage_marches="cheminement_ext_reperage_marches"|negative_text main_courante="cheminement_ext_main_courante"|negative_text|lower %}
+{{ reperage_marches }} et {{ main_courante }}
+{% endblocktranslate %}
+    {% endif %}
+{% endif %}

--- a/templates/erp/includes/access_value.html
+++ b/templates/erp/includes/access_value.html
@@ -1,0 +1,6 @@
+{% load a4a %}
+{% if value %}
+    <li>{{ value_name|positive_text }}</li>
+{% else %}
+    <li>{{ value_name|negative_text }}</li>
+{% endif %}

--- a/templates/erp/index.html
+++ b/templates/erp/index.html
@@ -43,18 +43,31 @@
             <div class="d-flex flex-column">
                 <div class="row order-2">
                     <section id="a11y" class="col-lg-7 col-xl-8">
-                        {% if accessibilite_data %}
-                            {% include "erp/includes/accessibilite.html" %}
-                            <aside class="text-center">
-                                {% include "erp/includes/vote-form.html" %}
-                            </aside>
+                        {% if show_new_access_data %}
+                            {% include "erp/includes/access_parking.html" %}
+                            {% include "erp/includes/access_outside_path.html" %}
+                            {% include "erp/includes/access_entrance.html" %}
+                            {% include "erp/includes/access_reception.html" %}
+                            {% if erp.is_accommodation %}
+                                {% include "erp/includes/access_accommodation.html" %}
+                            {% endif %}
+                            {% if access.registre_url or acces.conformite %}
+                                {% include "erp/includes/access_legal.html" %}
+                            {% endif %}
                         {% else %}
-                            <div class="alert alert-info">
-                                <i aria-hidden="true" class="icon icon-info-circled"></i>
-                                {% url "contrib_edit_infos" erp_slug=erp.slug as url_contrib %}
-                                {% blocktranslate %}Les données d'accessibilité pour cet établissement ne sont pas encore disponibles,
+                            {% if accessibilite_data %}
+                                {% include "erp/includes/accessibilite.html" %}
+                                <aside class="text-center">
+                                    {% include "erp/includes/vote-form.html" %}
+                                </aside>
+                            {% else %}
+                                <div class="alert alert-info">
+                                    <i aria-hidden="true" class="icon icon-info-circled"></i>
+                                    {% url "contrib_edit_infos" erp_slug=erp.slug as url_contrib %}
+                                    {% blocktranslate %}Les données d'accessibilité pour cet établissement ne sont pas encore disponibles,
             mais <a href="{{url_contrib}}">vous pouvez les ajouter</a>.{% endblocktranslate %}
-                            </div>
+                                </div>
+                            {% endif %}
                         {% endif %}
                     </section>
                     <aside class="col-lg-5 col-xl-4">


### PR DESCRIPTION
Add a new way of displaying the accessbility data on the ERP details page to try and make it more readable.

The main change we have here is that we stop considering that the way we store the data is the same way we should display the data to the end user.
Now some bullet points are a built by adding the information of one, two or three fields in the database. This is an attempt to improve the readability of the accessbility data.