### PR TITLE
Use autocomplete=0 on BAN API.

### DIFF
--- a/erp/provider/generic_geoloc.py
+++ b/erp/provider/generic_geoloc.py
@@ -23,7 +23,9 @@ class GeolocRequester:
 
         try:
             try:
-                data = self.query({"q": address, "postcode": postcode, "citycode": citycode, "limit": 1})
+                data = self.query(
+                    {"q": address, "postcode": postcode, "citycode": citycode, "limit": 1, "autocomplete": 0}
+                )
             except RuntimeError:
                 return {}
 


### PR DESCRIPTION
At this point we don't want to autocomplete an address, we have the complete one.
This param enhance the scoring, don't ask me why.
The default value is autocomplete=1, we only want it on client side, it is done in the `api.js` file.