### PR TITLE
Handle None values in new ERP display

### DIFF
--- a/erp/templatetags/a4a.py
+++ b/erp/templatetags/a4a.py
@@ -133,9 +133,11 @@ def negative_text(value):
 
 @register.simple_tag
 def access_text(value_name, access):
-    if getattr(access, value_name):
+    value = getattr(access, value_name)
+    if value is True:
         return schema.get_help_text_ui(value_name)
-    return schema.get_help_text_ui_neg(value_name)
+    if value is False:
+        return schema.get_help_text_ui_neg(value_name)
 
 
 @register.inclusion_tag("erp/includes/access_value.html")

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-18 10:38+0100\n"
+"POT-Creation-Date: 2024-03-19 10:56+0100\n"
 "PO-Revision-Date: 2024-02-28 10:26+0100\n"
 "Last-Translator: Marie-Laure3 Vernay <mlvernay@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3655,7 +3655,7 @@ msgid "Présence d'une pente de longueur %(longueur)s"
 msgstr ""
 
 #, python-format
-msgid "Dévers %(difficulty)s"
+msgid "Dévers %(difficulty)s </li>"
 msgstr ""
 
 msgid "Transport et stationnement"
@@ -3684,9 +3684,7 @@ msgid "Présence de marches %(extra_context)s"
 msgstr ""
 
 #, python-format
-msgid ""
-"\n"
-"%(reperage_marches)s et %(main_courante)s\n"
+msgid "%(reperage_marches)s et %(main_courante)s"
 msgstr ""
 
 msgid "Ce bâtiment est labellisé Tourisme et handicap"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-18 11:45+0100\n"
+"POT-Creation-Date: 2024-03-19 10:56+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3502,7 +3502,7 @@ msgid "Présence d'une pente de longueur %(longueur)s"
 msgstr ""
 
 #, python-format
-msgid "Dévers %(difficulty)s"
+msgid "Dévers %(difficulty)s </li>"
 msgstr ""
 
 msgid "Transport et stationnement"
@@ -3531,9 +3531,7 @@ msgid "Présence de marches %(extra_context)s"
 msgstr ""
 
 #, python-format
-msgid ""
-"\n"
-"%(reperage_marches)s et %(main_courante)s\n"
+msgid "%(reperage_marches)s et %(main_courante)s"
 msgstr ""
 
 msgid "Ce bâtiment est labellisé Tourisme et handicap"

--- a/static/scss/style.scss
+++ b/static/scss/style.scss
@@ -908,3 +908,9 @@ div.equipments-selected
 .team .fr-card {
   min-height: 10rem;
 }
+
+.remove-title-if-empty {
+  h4:has(+ ul:empty) {
+    display: none;
+  }
+}

--- a/templates/erp/includes/access_accommodation.html
+++ b/templates/erp/includes/access_accommodation.html
@@ -4,40 +4,42 @@
 <h4 class="pt-2 h4">
     <i aria-hidden="true" class="icon icon-house mr-1 larger-font"></i>{% translate "Hébergement" %}
 </h4>
-<ul>
-    <li>
-        {% if access.accueil_chambre_nombre_accessibles %}
-            {% if access.access.accueil_chambre_nombre_accessibles == 1 %}
-                {% translate "Au moins une chambre accessible à une personne en fauteuil roulant" %}
+{% spaceless %}
+    <ul>
+        <li>
+            {% if access.accueil_chambre_nombre_accessibles %}
+                {% if access.access.accueil_chambre_nombre_accessibles == 1 %}
+                    {% translate "Au moins une chambre accessible à une personne en fauteuil roulant" %}
+                {% else %}
+                    {% blocktranslate trimmed with nb=access.accueil_chambre_nombre_accessibles %}
+                        {{ nb }} chambres accessibles à une personne en fauteuil roulant
+                    {% endblocktranslate %}
+                {% endif %}
             {% else %}
-                {% blocktranslate trimmed with nb=access.accueil_chambre_nombre_accessibles %}
-                    {{ nb }} chambres accessibles à une personne en fauteuil roulant
-                {% endblocktranslate %}
+                {{ "accueil_chambre_nombre_accessibles"|negative_text }}
             {% endif %}
-        {% else %}
-            {{ "accueil_chambre_nombre_accessibles"|negative_text }}
+        </li>
+        {% if access.accueil_chambre_douche_plain_pied or access.accueil_chambre_douche_siege or access.accueil_chambre_douche_barre_appui %}
+            <li>
+                {% access_text "accueil_chambre_douche_plain_pied" access as plain_pied_text %}
+                {% access_text "accueil_chambre_douche_siege" access as siege_text %}
+                {% access_text "accueil_chambre_douche_barre_appui" access as appui_text %}
+                {% blocktranslate trimmed with type=plain_pied_text siege=siege_text|lower appui=appui_text|lower %}
+                    {{ plain_pied_text }} {{ siege }} et {{ appui }}
+                {% endblocktranslate %}
+            </li>
         {% endif %}
-    </li>
-    {% if access.accueil_chambre_douche_plain_pied or access.accueil_chambre_douche_siege or access.accueil_chambre_douche_barre_appui %}
-        <li>
-            {% access_text "accueil_chambre_douche_plain_pied" access as plain_pied_text %}
-            {% access_text "accueil_chambre_douche_siege" access as siege_text %}
-            {% access_text "accueil_chambre_douche_barre_appui" access as appui_text %}
-            {% blocktranslate trimmed with type=plain_pied_text siege=siege_text|lower appui=appui_text|lower %}
-                {{ plain_pied_text }} {{ siege }} et {{ appui }}
-            {% endblocktranslate %}
-        </li>
-    {% endif %}
-    {% if access.accueil_chambre_sanitaires_barre_appui or access.accueil_chambre_sanitaires_espace_usage %}
-        <li>
-            {% access_text "accueil_chambre_sanitaires_espace_usage" access as espace_text %}
-            {% access_text "accueil_chambre_sanitaires_barre_appui" access as appui_text %}
-            {% blocktranslate trimmed with espace=espace_text|lower appui=appui_text|lower %}
-                Toilettes {{ espace }} et {{ appui }}
-            {% endblocktranslate %}
-        </li>
-    {% endif %}
-    {% render_access_value "accueil_chambre_numero_visible" access %}
-    {% render_access_value "accueil_chambre_equipement_alerte" access %}
-    {% render_access_value "accueil_chambre_accompagnement" access %}
-</ul>
+        {% if access.accueil_chambre_sanitaires_barre_appui or access.accueil_chambre_sanitaires_espace_usage %}
+            <li>
+                {% access_text "accueil_chambre_sanitaires_espace_usage" access as espace_text %}
+                {% access_text "accueil_chambre_sanitaires_barre_appui" access as appui_text %}
+                {% blocktranslate trimmed with espace=espace_text|lower appui=appui_text|lower %}
+                    Toilettes {{ espace }} et {{ appui }}
+                {% endblocktranslate %}
+            </li>
+        {% endif %}
+        {% render_access_value "accueil_chambre_numero_visible" access %}
+        {% render_access_value "accueil_chambre_equipement_alerte" access %}
+        {% render_access_value "accueil_chambre_accompagnement" access %}
+    </ul>
+{% endspaceless %}

--- a/templates/erp/includes/access_entrance.html
+++ b/templates/erp/includes/access_entrance.html
@@ -4,73 +4,73 @@
 <h4 class="pt-2 h4">
     <i aria-hidden="true" class="icon icon-entrance mr-1 larger-font"></i>{% translate "Entrée" %}
 </h4>
-<ul>
-    {% render_access_value "entree_reperage" access %}
-    {% if access.entree_balise_sonore %}<li>{{ "entree_balise_sonore"|positive_text }}</li>{% endif %}
-    {% if not access.entree_porte_presence %}<li>{{ "entree_porte_presence"|negative_text }}</li>{% endif %}
-    {% if access.entree_porte_type %}
-        {% if access.entree_porte_manoeuvre %}
-            <li>
-                {% blocktranslate trimmed with type=access.entree_porte_type manoeuvre=access.entree_porte_manoeuvre %}
-                    Porte {{ type }} {{ manoeuvre }}
-                {% endblocktranslate %}
-            </li>
-        {% else %}
-            <li>
-                {% blocktranslate trimmed with type=access.entree_porte_type %}
-                    Porte {{ type }}
-                {% endblocktranslate %}
-            </li>
-        {% endif %}
-    {% else %}
-        {% if access.entree_porte_manoeuvre %}
-            <li>
-                {% blocktranslate trimmed with manoeuvre=access.entree_porte_manoeuvre %}
-                    Porte {{ manoeuvre }}
-                {% endblocktranslate %}
-            </li>
-        {% endif %}
-    {% endif %}
-    {% if access.entree_largeur_mini >= 80 %}
-        <li>{{ "entree_largeur_mini"|positive_text }}</li>
-    {% else %}
-        <li>{{ "entree_largeur_mini"|negative_text }}</li>
-    {% endif %}
-    <li>
-        {% if access.entree_vitree %}
-            {{ "entree_vitree"|positive_text }} {{ "entree_vitree_vitrophanie"|positive_text|lower }}
-        {% else %}
-            {{ "entree_vitree"|negative_text }}
-        {% endif %}
-    </li>
-    <li>
-        {% if access.entree_plain_pied %}
-            {{ "entree_plain_pied"|positive_text }}
-        {% else %}
-            {% translate "pour atteindre l'entrée" as extra_context %}
-            {% include "erp/includes/access_stairs.html" with steps_direction=access.entree_marches_sens nb_steps=access.entree_marches %}
-        {% endif %}
-    </li>
-    <li>
-        {% include "erp/includes/access_steps.html" with main_courante_data=access.entree_marches_main_courante reperage=access.entree_marches_reperage %}
-    </li>
-    {% render_access_value "entree_marches_rampe" access %}
-    {% if access.cheminement_ext_ascenseur %}<li>{{ "cheminement_ext_ascenseur"|positive_text }}</li>{% endif %}
-    {% if access.entree_aide_humaine %}<li>{{ "entree_aide_humaine"|positive_text }}</li>{% endif %}
-    {% if access.entree_dispositif_appel %}
-        {% if access.entree_dispositif_appel_type %}
-            {% for equipment in access.entree_dispositif_appel_type %}<li>{{ equipment|title }}</li>{% endfor %}
-        {% else %}
-            <li>{{ "entree_dispositif_appel"|positive_text }}</li>
-        {% endif %}
-    {% endif %}
-    {% if access.entree_pmr %}
-        <li>
-            {{ "entree_pmr"|positive_text }}
-            {% if access.entree_pmr_informations %}
-                <br />
-                {{ entree_pmr_informations }}
+{% spaceless %}
+    <ul>
+        {% render_access_value "entree_reperage" access %}
+        {% if access.entree_balise_sonore %}<li>{{ "entree_balise_sonore"|positive_text }}</li>{% endif %}
+        {% if access.entree_porte_presence is False %}<li>{{ "entree_porte_presence"|negative_text }}</li>{% endif %}
+        {% if access.entree_porte_type %}
+            {% if access.entree_porte_manoeuvre %}
+                <li>
+                    {% blocktranslate trimmed with type=access.entree_porte_type manoeuvre=access.entree_porte_manoeuvre %}
+                        Porte {{ type }} {{ manoeuvre }}
+                    {% endblocktranslate %}
+                </li>
+            {% else %}
+                <li>
+                    {% blocktranslate trimmed with type=access.entree_porte_type %}
+                        Porte {{ type }}
+                    {% endblocktranslate %}
+                </li>
             {% endif %}
+        {% else %}
+            {% if access.entree_porte_manoeuvre %}
+                <li>
+                    {% blocktranslate trimmed with manoeuvre=access.entree_porte_manoeuvre %}
+                        Porte {{ manoeuvre }}
+                    {% endblocktranslate %}
+                </li>
+            {% endif %}
+        {% endif %}
+        {% if access.entree_largeur_mini >= 80 %}
+            <li>{{ "entree_largeur_mini"|positive_text }}</li>
+        {% else %}
+            <li>{{ "entree_largeur_mini"|negative_text }}</li>
+        {% endif %}
+        {% if access.entree_vitree %}
+            <li>{{ "entree_vitree"|positive_text }} {{ "entree_vitree_vitrophanie"|positive_text|lower }}</li>
+        {% elif access.entree_vitree is False %}
+            <li>{{ "entree_vitree"|negative_text }}</li>
+        {% endif %}
+        {% if access.entree_plain_pied %}
+            <li>{{ "entree_plain_pied"|positive_text }}</li>
+        {% elif access.entree_plain_pied is False %}
+            <li>
+                {% translate "pour atteindre l'entrée" as extra_context %}
+                {% include "erp/includes/access_stairs.html" with steps_direction=access.entree_marches_sens nb_steps=access.entree_marches %}
+            </li>
+        {% endif %}
+        <li>
+            {% include "erp/includes/access_steps.html" with main_courante_data=access.entree_marches_main_courante reperage=access.entree_marches_reperage %}
         </li>
-    {% endif %}
-</ul>
+        {% render_access_value "entree_marches_rampe" access %}
+        {% if access.cheminement_ext_ascenseur %}<li>{{ "cheminement_ext_ascenseur"|positive_text }}</li>{% endif %}
+        {% if access.entree_aide_humaine %}<li>{{ "entree_aide_humaine"|positive_text }}</li>{% endif %}
+        {% if access.entree_dispositif_appel %}
+            {% if access.entree_dispositif_appel_type %}
+                {% for equipment in access.entree_dispositif_appel_type %}<li>{{ equipment|title }}</li>{% endfor %}
+            {% else %}
+                <li>{{ "entree_dispositif_appel"|positive_text }}</li>
+            {% endif %}
+        {% endif %}
+        {% if access.entree_pmr %}
+            <li>
+                {{ "entree_pmr"|positive_text }}
+                {% if access.entree_pmr_informations %}
+                    <br />
+                    {{ entree_pmr_informations }}
+                {% endif %}
+            </li>
+        {% endif %}
+    </ul>
+{% endspaceless %}

--- a/templates/erp/includes/access_outside_path.html
+++ b/templates/erp/includes/access_outside_path.html
@@ -4,56 +4,57 @@
 <h4 class="pt-2 h4">
     <i aria-hidden="true" class="icon icon-road mr-1 larger-font"></i>{% translate "Chemin vers l'entrée" %}
 </h4>
-<ul>
-    {% if access.has_outside_path_and_no_other_data %}<li>{{ "cheminement_ext_presence"|positive_text }}</li>{% endif %}
-    {% if access.cheminement_ext_bande_guidage %}<li>{{ "cheminement_ext_bande_guidage"|positive_text }}</li>{% endif %}
-    {% if access.cheminement_ext_plain_pied %}
-        <li>{{ "cheminement_ext_plain_pied"|positive_text }}</li>
-    {% else %}
+{% spaceless %}
+    <ul>
+        {% if access.has_outside_path_and_no_other_data %}<li>{{ "cheminement_ext_presence"|positive_text }}</li>{% endif %}
+        {% if access.cheminement_ext_bande_guidage %}<li>{{ "cheminement_ext_bande_guidage"|positive_text }}</li>{% endif %}
+        {% if access.cheminement_ext_plain_pied %}
+            <li>{{ "cheminement_ext_plain_pied"|positive_text }}</li>
+        {% elif access.cheminement_ext_plain_pied is False %}
+            <li>
+                {% translate "sur le chemin" as extra_context %}
+                {% include "erp/includes/access_stairs.html" with steps_direction=access.cheminement_ext_sens_marches nb_steps=access.cheminement_ext_nombre_marches extra_context=extra_context %}
+            </li>
+        {% endif %}
         <li>
-            {% translate "sur le chemin" as extra_context %}
-            {% include "erp/includes/access_stairs.html" with steps_direction=access.cheminement_ext_sens_marches nb_steps=access.cheminement_ext_nombre_marches extra_context=extra_context %}
+            {% include "erp/includes/access_steps.html" with main_courante_data=access.cheminement_ext_main_courante reperage=access.cheminement_ext_reperage_marches %}
         </li>
-    {% endif %}
-    <li>
-        {% include "erp/includes/access_steps.html" with main_courante_data=access.cheminement_ext_main_courante reperage=access.cheminement_ext_reperage_marches %}
-    </li>
-    {% render_access_value "cheminement_ext_rampe" access %}
-    {% if access.cheminement_ext_ascenseur %}<li>{{ "cheminement_ext_ascenseur"|positive_text }}</li>{% endif %}
-    {% render_access_value "cheminement_ext_retrecissement" access %}
-    {% if access.cheminement_ext_pente_presence %}
-        {% if access.cheminement_ext_pente_degre_difficulte %}
-            {% if access.cheminement_ext_pente_longueur %}
-                <li>
-                    {% blocktranslate trimmed with longueur=access.cheminement_ext_pente_longueur difficulte=access.cheminement_ext_pente_degre_difficulte %}
-                        Présence d'une pente {{ difficulte }} de longueur {{ longueur }}
-                    {% endblocktranslate %}
-                </li>
+        {% render_access_value "cheminement_ext_rampe" access %}
+        {% if access.cheminement_ext_ascenseur %}<li>{{ "cheminement_ext_ascenseur"|positive_text }}</li>{% endif %}
+        {% if access.cheminement_ext_pente_presence %}
+            {% if access.cheminement_ext_pente_degre_difficulte %}
+                {% if access.cheminement_ext_pente_longueur %}
+                    <li>
+                        {% blocktranslate trimmed with longueur=access.cheminement_ext_pente_longueur difficulte=access.cheminement_ext_pente_degre_difficulte %}
+                            Présence d'une pente {{ difficulte }} de longueur {{ longueur }}
+                        {% endblocktranslate %}
+                    </li>
+                {% else %}
+                    <li>
+                        {% blocktranslate trimmed with difficulte=access.cheminement_ext_pente_degre_difficulte %}
+                            Présence d'une pente {{ difficulte }}
+                        {% endblocktranslate %}
+                    </li>
+                {% endif %}
             {% else %}
                 <li>
-                    {% blocktranslate trimmed with difficulte=access.cheminement_ext_pente_degre_difficulte %}
-                        Présence d'une pente {{ difficulte }}
-                    {% endblocktranslate %}
-                </li>
-            {% endif %}
-        {% else %}
-            <li>
-                {% if access.cheminement_ext_pente_longueur %}
-                    {% blocktranslate trimmed with longueur=access.cheminement_ext_pente_longueur %}
-                        Présence d'une pente de longueur {{ longueur }}
-                    {% endblocktranslate %}
-                </li>
+                    {% if access.cheminement_ext_pente_longueur %}
+                        {% blocktranslate trimmed with longueur=access.cheminement_ext_pente_longueur %}
+                            Présence d'une pente de longueur {{ longueur }}
+                        {% endblocktranslate %}
+                    </li>
+                {% endif %}
             {% endif %}
         {% endif %}
-    {% endif %}
-    <li>
         {% if access.has_camber %}
-            {% blocktranslate trimmed with difficulty=access.cheminement_ext_devers %}
-                Dévers {{ difficulty }}
+            <li>
+                {% blocktranslate trimmed with difficulty=access.cheminement_ext_devers %}
+                    Dévers {{ difficulty }}
+                </li>
             {% endblocktranslate %}
-        {% else %}
-            {{ "cheminement_ext_devers"|negative_text }}
+        {% elif access.has_camber is False %}
+            <li>{{ "cheminement_ext_devers"|negative_text }}</li>
         {% endif %}
-    </li>
-    {% render_access_value "cheminement_ext_retrecissement" access %}
-</ul>
+        {% render_access_value "cheminement_ext_retrecissement" access %}
+    </ul>
+{% endspaceless %}

--- a/templates/erp/includes/access_parking.html
+++ b/templates/erp/includes/access_parking.html
@@ -1,32 +1,34 @@
 {% load a4a %}
 {% load static %}
 {% load i18n %}
-<h4 class="pt-2 h4">
+<h4 class="pt-2 h4 hide-if-empty">
     <i aria-hidden="true" class="icon icon-bus mr-1 larger-font"></i>{% translate "Transport et stationnement" %}
 </h4>
-<ul>
-    {% if access.transport_station_presence %}
-        <li>
-            {{ "transport_station_presence"|positive_text }}
-            {% if access.transport_information %}: {{ access.transport_information }}{% endif %}
-        </li>
-    {% endif %}
-    {% if access.stationnement_presence %}
-        {% if access.stationnement_pmr %}
-            <li>{{ "stationnement_pmr"|positive_text }}</li>
-        {% else %}
-            <li>{{ "stationnement_presence"|positive_text }}</li>
+{% spaceless %}
+    <ul>
+        {% if access.transport_station_presence %}
+            <li>
+                {{ "transport_station_presence"|positive_text }}
+                {% if access.transport_information %}: {{ access.transport_information }}{% endif %}
+            </li>
         {% endif %}
-    {% else %}
-        <li>{{ "stationnement_presence"|negative_text }}</li>
-    {% endif %}
-    {% if access.stationnement_ext_presence %}
-        {% if access.stationnement_ext_pmr %}
-            <li>{{ "stationnement_ext_pmr"|positive_text }}</li>
-        {% else %}
-            <li>{{ "stationnement_ext_presence"|positive_text }}</li>
+        {% if access.stationnement_presence %}
+            {% if access.stationnement_pmr %}
+                <li>{{ "stationnement_pmr"|positive_text }}</li>
+            {% else %}
+                <li>{{ "stationnement_presence"|positive_text }}</li>
+            {% endif %}
+        {% elif access.stationnement_presence is False %}
+            <li>{{ "stationnement_presence"|negative_text }}</li>
         {% endif %}
-    {% else %}
-        <li>{{ "stationnement_ext_presence"|negative_text }}</li>
-    {% endif %}
-</ul>
+        {% if access.stationnement_ext_presence %}
+            {% if access.stationnement_ext_pmr %}
+                <li>{{ "stationnement_ext_pmr"|positive_text }}</li>
+            {% else %}
+                <li>{{ "stationnement_ext_presence"|positive_text }}</li>
+            {% endif %}
+        {% elif stationnement_ext_presence is False %}
+            <li>{{ "stationnement_ext_presence"|negative_text }}</li>
+        {% endif %}
+    </ul>
+{% endspaceless %}

--- a/templates/erp/includes/access_reception.html
+++ b/templates/erp/includes/access_reception.html
@@ -4,46 +4,46 @@
 <h4 class="pt-2 h4">
     <i aria-hidden="true" class="icon icon-users mr-1 larger-font"></i>{% translate "Accueil et équipement" %}
 </h4>
-<ul>
-    {% render_access_value "accueil_visibilite" access %}
-    <li>
+{% spaceless %}
+    <ul>
+        {% render_access_value "accueil_visibilite" access %}
         {% if access.accueil_cheminement_plain_pied %}
-            {{ "accueil_cheminement_plain_pied"|positive_text }}
-        {% else %}
+            <li>{{ "accueil_cheminement_plain_pied"|positive_text }}</li>
+        {% elif access.accueil_cheminement_plain_pied is False %}
             {% translate "pour atteindre l'accueil" as extra_context %}
-            {% include "erp/includes/access_stairs.html" with steps_direction=access.accueil_cheminement_sens_marches nb_steps=access.accueil_cheminement_nombre_marches extra_context=extra_context %}
+            <li>
+                {% include "erp/includes/access_stairs.html" with steps_direction=access.accueil_cheminement_sens_marches nb_steps=access.accueil_cheminement_nombre_marches extra_context=extra_context %}
+            </li>
         {% endif %}
-    </li>
-    <li>
-        {% include "erp/includes/access_steps.html" with main_courante_data=access.accueil_cheminement_main_courante reperage=access.accueil_cheminement_reperage_marches %}
-    </li>
-    {% render_access_value "accueil_cheminement_rampe" access %}
-    {% if access.accueil_cheminement_ascenseur %}<li>{{ "accueil_cheminement_ascenseur"|positive_text }}</li>{% endif %}
-    {% render_access_value "accueil_retrecissement" access %}
-    {% if access.accueil_personnels %}<li>{{ access.get_accueil_personnels_display }}</li>{% endif %}
-    {% if access.accueil_audiodescription %}
-        <li>{{ access.get_accueil_audiodescription_display }}</li>
-    {% else %}
-        <li>{{ "accueil_audiodescription_presence"|negative_text }}</li>
-    {% endif %}
-    {% if access.accueil_equipements_malentendants_presence %}
-        {% if access.accueil_equipements_malentendants %}
-            {% for equipment in access.accueil_equipements_malentendants %}<li>{{ equipment|title }}</li>{% endfor %}
-        {% else %}
-            <li>{{ "accueil_equipements_malentendants_presence"|positive_text }}</li>
+        <li>
+            {% include "erp/includes/access_steps.html" with main_courante_data=access.accueil_cheminement_main_courante reperage=access.accueil_cheminement_reperage_marches %}
+        </li>
+        {% render_access_value "accueil_cheminement_rampe" access %}
+        {% if access.accueil_cheminement_ascenseur %}<li>{{ "accueil_cheminement_ascenseur"|positive_text }}</li>{% endif %}
+        {% render_access_value "accueil_retrecissement" access %}
+        {% if access.accueil_personnels %}<li>{{ access.get_accueil_personnels_display }}</li>{% endif %}
+        {% if access.accueil_audiodescription %}
+            <li>{{ access.get_accueil_audiodescription_display }}</li>
+        {% elif access.accueil_audiodescription is False %}
+            <li>{{ "accueil_audiodescription_presence"|negative_text }}</li>
         {% endif %}
-    {% else %}
-        <li>{{ "accueil_equipements_malentendants_presence"|negative_text }}</li>
-    {% endif %}
-    <li>
+        {% if access.accueil_equipements_malentendants_presence %}
+            {% if access.accueil_equipements_malentendants %}
+                {% for equipment in access.accueil_equipements_malentendants %}<li>{{ equipment|title }}</li>{% endfor %}
+            {% else %}
+                <li>{{ "accueil_equipements_malentendants_presence"|positive_text }}</li>
+            {% endif %}
+        {% elif access.accueil_equipements_malentendants_presence is False %}
+            <li>{{ "accueil_equipements_malentendants_presence"|negative_text }}</li>
+        {% endif %}
         {% if access.sanitaires_presence %}
             {% if access.sanitaires_adaptes %}
-                {% translate "Toilettes PMR" %}
+                <li>{% translate "Toilettes PMR" %}</li>
             {% else %}
-                {% translate "Toilettes classiques" %}
+                <li>{% translate "Toilettes classiques" %}</li>
             {% endif %}
-        {% else %}
-            {{ "sanitaires_presence"|negative_text }}
+        {% elif access.sanitaires_presence is False %}
+            <li>{{ "sanitaires_presence"|negative_text }}</li>
         {% endif %}
-    </li>
-</ul>
+    </ul>
+{% endspaceless %}

--- a/templates/erp/includes/access_steps.html
+++ b/templates/erp/includes/access_steps.html
@@ -2,22 +2,22 @@
 {% load i18n %}
 {% if reperage %}
     {% if main_courante_data %}
-        {% blocktranslate with reperage_marches="cheminement_ext_reperage_marches"|positive_text main_courante="cheminement_ext_main_courante"|positive_text|lower %}
-{{ reperage_marches }} et {{ main_courante }}
-{% endblocktranslate %}
+        {% blocktranslate trimmed with reperage_marches="cheminement_ext_reperage_marches"|positive_text main_courante="cheminement_ext_main_courante"|positive_text|lower %}
+            {{ reperage_marches }} et {{ main_courante }}
+        {% endblocktranslate %}
     {% else %}
-        {% blocktranslate with reperage_marches="cheminement_ext_reperage_marches"|positive_text main_courante="cheminement_ext_main_courante"|negative_text|lower %}
-{{ reperage_marches }} et {{ main_courante }}
-{% endblocktranslate %}
+        {% blocktranslate trimmed with reperage_marches="cheminement_ext_reperage_marches"|positive_text main_courante="cheminement_ext_main_courante"|negative_text|lower %}
+            {{ reperage_marches }} et {{ main_courante }}
+        {% endblocktranslate %}
     {% endif %}
 {% else %}
     {% if main_courante_data %}
-        {% blocktranslate with reperage_marches="cheminement_ext_reperage_marches"|negative_text main_courante="cheminement_ext_main_courante"|positive_text|lower %}
-{{ reperage_marches }} et {{ main_courante }}
-{% endblocktranslate %}
+        {% blocktranslate trimmed with reperage_marches="cheminement_ext_reperage_marches"|negative_text main_courante="cheminement_ext_main_courante"|positive_text|lower %}
+            {{ reperage_marches }} et {{ main_courante }}
+        {% endblocktranslate %}
     {% else %}
-        {% blocktranslate with reperage_marches="cheminement_ext_reperage_marches"|negative_text main_courante="cheminement_ext_main_courante"|negative_text|lower %}
-{{ reperage_marches }} et {{ main_courante }}
-{% endblocktranslate %}
+        {% blocktranslate trimmed with reperage_marches="cheminement_ext_reperage_marches"|negative_text main_courante="cheminement_ext_main_courante"|negative_text|lower %}
+            {{ reperage_marches }} et {{ main_courante }}
+        {% endblocktranslate %}
     {% endif %}
 {% endif %}

--- a/templates/erp/includes/access_value.html
+++ b/templates/erp/includes/access_value.html
@@ -1,6 +1,6 @@
 {% load a4a %}
 {% if value %}
     <li>{{ value_name|positive_text }}</li>
-{% else %}
+{% elif value is False %}
     <li>{{ value_name|negative_text }}</li>
 {% endif %}

--- a/templates/erp/index.html
+++ b/templates/erp/index.html
@@ -42,7 +42,7 @@
             </aside>
             <div class="d-flex flex-column">
                 <div class="row order-2">
-                    <section id="a11y" class="col-lg-7 col-xl-8">
+                    <section id="a11y" class="col-lg-7 col-xl-8 remove-title-if-empty">
                         {% if show_new_access_data %}
                             {% include "erp/includes/access_parking.html" %}
                             {% include "erp/includes/access_outside_path.html" %}


### PR DESCRIPTION
The None values where not handled correctly in most of the places, this commit tries to fix this.
I also fixed the fact that we could display title when the section was empty. I could not do it inside the view (we do not know what we are going to display) and did not wanted to it in Js.

If the `:empty` selector was handled correctly in the browsers with CSS4 selectors we could have use it directly but I had to remove all the spaces with the `spaceless` template tag to clean the HTML.

https://developer.mozilla.org/fr/docs/Web/CSS/:empty