### PR TITLE
Add filters on ERP detail page

### DIFF
--- a/erp/templatetags/a4a.py
+++ b/erp/templatetags/a4a.py
@@ -159,8 +159,8 @@ def access_text(value_name, access):
 
 
 @register.inclusion_tag("erp/includes/access_value.html")
-def render_access_value(value_name, access):
-    return {"value_name": value_name, "access": access, "value": getattr(access, value_name)}
+def render_access_value(value_name, access, filters=None):
+    return {"value_name": value_name, "access": access, "value": getattr(access, value_name), "filters": filters}
 
 
 @register.simple_tag

--- a/static/index.js
+++ b/static/index.js
@@ -44,6 +44,7 @@ dom.ready(() => {
   dom.mountOne('#clone-filter-submit', cloneFilter.cloneFilterSubmit)
   dom.mountOne('#no_activity', ui.NewActivity)
   dom.mountOne('#unsure-and-submit', ui.PickAnswerAndSubmit)
+  dom.mountOne('#filter-controller', ui.filterData)
 })
 
 // expose general namespaced lib for usage within pages

--- a/static/js/ui/FilterData.js
+++ b/static/js/ui/FilterData.js
@@ -1,0 +1,50 @@
+function hasVisibleChildren(element) {
+  let visibleChildren = false
+  Array.from(element.children).forEach(function (child) {
+    if (child.offsetWidth > 0) {
+      visibleChildren = true
+    }
+  })
+  return visibleChildren
+}
+
+function filterData(root) {
+  const dataToToogle = root.querySelectorAll('[data-filters]')
+  document.addEventListener('filterClicked', () => {
+    const inputFilters = document.querySelectorAll('[name=erp_filter]:checked')
+    const activeFilters = Array.from(inputFilters).map((filter) => filter.value)
+    const titlesToToogle = root.querySelectorAll('[data-filter-title]')
+
+    if (activeFilters.length === 0) {
+      dataToToogle.forEach((element) => {
+        element.classList.remove('hidden')
+      })
+      titlesToToogle.forEach((element) => {
+        element.classList.remove('hidden')
+      })
+      return
+    }
+
+    dataToToogle.forEach((element) => {
+      const filtersForElement = element.dataset.filters
+      const filterFound = activeFilters.some((filter) => filtersForElement.includes(filter))
+      const forceDisplay = filtersForElement.includes('all')
+      if (filterFound || forceDisplay) {
+        element.classList.remove('hidden')
+      } else {
+        element.classList.add('hidden')
+      }
+    })
+
+    titlesToToogle.forEach((titleElement) => {
+      const shouldBeVisible = hasVisibleChildren(titleElement.nextElementSibling)
+      if (shouldBeVisible === true) {
+        titleElement.classList.remove('hidden')
+      } else {
+        titleElement.classList.add('hidden')
+      }
+    })
+  })
+}
+
+export default filterData

--- a/static/js/ui/LabelTag.js
+++ b/static/js/ui/LabelTag.js
@@ -1,6 +1,8 @@
 function LabelTag(root) {
   root.addEventListener('click', function (event) {
     let eventType = root.getAttribute('data-event-type')
+    const input = event.target.parentElement.querySelector('input')
+    input.checked = !input.checked
     document.dispatchEvent(new CustomEvent(eventType, { detail: { source: event.target } }))
   })
 }

--- a/static/js/ui/index.js
+++ b/static/js/ui/index.js
@@ -10,6 +10,7 @@ import NewActivity from './NewActivity'
 import listenToLabelEvents from './GroupLabelTag'
 import ProgressBar from './ProgressBar'
 import PickAnswerAndSubmit from './PickAnswerAndSubmit'
+import filterData from './FilterData'
 
 export default {
   AsteriskField,
@@ -24,4 +25,5 @@ export default {
   listenToLabelEvents,
   ProgressBar,
   PickAnswerAndSubmit,
+  filterData: filterData,
 }

--- a/templates/erp/includes/access_accommodation.html
+++ b/templates/erp/includes/access_accommodation.html
@@ -1,12 +1,12 @@
 {% load a4a %}
 {% load static %}
 {% load i18n %}
-<h4 class="pt-2 h4">
+<h4 class="pt-2 h4" data-filter-title="true">
     <i aria-hidden="true" class="icon icon-house mr-1 larger-font"></i>{% translate "Hébergement" %}
 </h4>
 {% spaceless %}
     <ul>
-        <li>
+        <li data-filters="walking">
             {% if access.accueil_chambre_nombre_accessibles %}
                 {% if access.access.accueil_chambre_nombre_accessibles == 1 %}
                     {% translate "Au moins une chambre accessible à une personne en fauteuil roulant" %}
@@ -22,7 +22,7 @@
             {% endif %}
         </li>
         {% if access.accueil_chambre_douche_plain_pied is not None or access.accueil_chambre_douche_siege is not None or access.accueil_chambre_douche_barre_appui is not None %}
-            <li>
+            <li data-filters="walking">
                 {% access_text "accueil_chambre_douche_plain_pied" access as plain_pied_text %}
                 {% access_text "accueil_chambre_douche_siege" access as siege_text %}
                 {% access_text "accueil_chambre_douche_barre_appui" access as appui_text %}
@@ -32,7 +32,7 @@
             </li>
         {% endif %}
         {% if access.accueil_chambre_sanitaires_barre_appui is not None or access.accueil_chambre_sanitaires_espace_usage is not None %}
-            <li>
+            <li data-filters="walking">
                 {% access_text "accueil_chambre_sanitaires_espace_usage" access as espace_text %}
                 {% access_text "accueil_chambre_sanitaires_barre_appui" access as appui_text %}
                 {% blocktranslate trimmed with espace=espace_text|lower appui=appui_text|lower %}
@@ -40,8 +40,8 @@
                 {% endblocktranslate %}
             </li>
         {% endif %}
-        {% render_access_value "accueil_chambre_numero_visible" access %}
-        {% render_access_value "accueil_chambre_equipement_alerte" access %}
-        {% render_access_value "accueil_chambre_accompagnement" access %}
+        {% render_access_value "accueil_chambre_numero_visible" access "all" %}
+        {% render_access_value "accueil_chambre_equipement_alerte" access "hearing" %}
+        {% render_access_value "accueil_chambre_accompagnement" access "all" %}
     </ul>
 {% endspaceless %}

--- a/templates/erp/includes/access_comment.html
+++ b/templates/erp/includes/access_comment.html
@@ -1,7 +1,7 @@
 {% load a4a %}
 {% load static %}
 {% load i18n %}
-<h4 class="pt-2 h4">
+<h4 class="pt-2 h4" data-filter-title="true">
     <i aria-hidden="true" class="icon icon-info-circled mr-1 larger-font"></i>{% translate "Commentaire" %}
 </h4>
 <blockquote class="a4a-comment-block">

--- a/templates/erp/includes/access_entrance.html
+++ b/templates/erp/includes/access_entrance.html
@@ -1,23 +1,27 @@
 {% load a4a %}
 {% load static %}
 {% load i18n %}
-<h4 class="pt-2 h4">
+<h4 class="pt-2 h4" data-filter-title="true">
     <i aria-hidden="true" class="icon icon-entrance mr-1 larger-font"></i>{% translate "Entrée" %}
 </h4>
 {% spaceless %}
     <ul>
-        {% render_access_value "entree_reperage" access %}
-        {% if access.entree_balise_sonore %}<li>{{ "entree_balise_sonore"|positive_text }}</li>{% endif %}
-        {% if access.entree_porte_presence is False %}<li>{{ "entree_porte_presence"|negative_text }}</li>{% endif %}
+        {% render_access_value "entree_reperage" access "all" %}
+        {% if access.entree_balise_sonore %}
+            <li data-filters="visual">{{ "entree_balise_sonore"|positive_text }}</li>
+        {% endif %}
+        {% if access.entree_porte_presence is False %}
+            <li data-filters="all">{{ "entree_porte_presence"|negative_text }}</li>
+        {% endif %}
         {% if access.entree_porte_type %}
             {% if access.entree_porte_manoeuvre %}
-                <li>
+                <li data-filters="all">
                     {% blocktranslate trimmed with type=access.entree_porte_type manoeuvre=access.entree_porte_manoeuvre %}
                         Porte {{ type }} {{ manoeuvre }}
                     {% endblocktranslate %}
                 </li>
             {% else %}
-                <li>
+                <li data-filters="all">
                     {% blocktranslate trimmed with type=access.entree_porte_type %}
                         Porte {{ type }}
                     {% endblocktranslate %}
@@ -25,7 +29,7 @@
             {% endif %}
         {% else %}
             {% if access.entree_porte_manoeuvre %}
-                <li>
+                <li data-filters="all">
                     {% blocktranslate trimmed with manoeuvre=access.entree_porte_manoeuvre %}
                         Porte {{ manoeuvre }}
                     {% endblocktranslate %}
@@ -33,48 +37,50 @@
             {% endif %}
         {% endif %}
         {% if access.entree_largeur_mini >= 80 %}
-            <li>{{ "entree_largeur_mini"|positive_text }}</li>
+            <li data-filters="walking">{{ "entree_largeur_mini"|positive_text }}</li>
         {% elif access.entree_largeur_mini < 80 %}
-            <li>{{ "entree_largeur_mini"|negative_text }}</li>
+            <li data-filters="walking">{{ "entree_largeur_mini"|negative_text }}</li>
         {% endif %}
         {% if access.entree_vitree %}
             {% if access.entree_vitree_vitrophanie is True %}
-                <li>{{ "entree_vitree"|positive_text }} {{ "entree_vitree_vitrophanie"|positive_text|lower }}</li>
+                <li data-filters="visual,understand">
+                    {{ "entree_vitree"|positive_text }} {{ "entree_vitree_vitrophanie"|positive_text|lower }}
+                </li>
             {% else %}
-                <li>{{ "entree_vitree"|positive_text }}</li>
+                <li data-filters="visual,understand">{{ "entree_vitree"|positive_text }}</li>
             {% endif %}
         {% elif access.entree_vitree is False %}
-            <li>{{ "entree_vitree"|negative_text }}</li>
+            <li data-filters="visual,understand">{{ "entree_vitree"|negative_text }}</li>
         {% endif %}
         {% if access.entree_plain_pied %}
-            <li>{{ "entree_plain_pied"|positive_text }}</li>
+            <li data-filters="visual,walking">{{ "entree_plain_pied"|positive_text }}</li>
         {% elif access.entree_plain_pied is False %}
-            <li>
+            <li data-filters="visual,walking">
                 {% translate "pour atteindre l'entrée" as extra_context %}
                 {% include "erp/includes/access_stairs.html" with steps_direction=access.get_entry_steps_direction_text nb_steps=access.entree_marches %}
             </li>
         {% endif %}
         {% include "erp/includes/access_steps.html" with nb_marches=access.entree_marches main_courante_data=access.entree_marches_main_courante reperage=access.entree_marches_reperage %}
         {% if access.has_ramp_entry %}
-            <li>
+            <li data-filters="walking">
                 {% blocktranslate trimmed with sentence="entree_marches_rampe"|positive_text rampe=access.entree_marches_rampe %}
                     {{ sentence }} {{ rampe }}
                 {% endblocktranslate %}
             </li>
         {% elif access.entree_marches_rampe is False %}
-            <li>{{ "entree_marches_rampe"|negative_text }}</li>
+            <li data-filters="walking">{{ "entree_marches_rampe"|negative_text }}</li>
         {% endif %}
-        {% if access.entree_ascenseur %}<li>{{ "entree_ascenseur"|positive_text }}</li>{% endif %}
-        {% if access.entree_aide_humaine %}<li>{{ "entree_aide_humaine"|positive_text }}</li>{% endif %}
+        {% if access.entree_ascenseur %}<li data-filters="walking,understand">{{ "entree_ascenseur"|positive_text }}</li>{% endif %}
+        {% if access.entree_aide_humaine %}<li data-filters="all">{{ "entree_aide_humaine"|positive_text }}</li>{% endif %}
         {% if access.entree_dispositif_appel %}
             {% if access.entree_dispositif_appel_type %}
-                {% for equipment in access.get_entree_dispositif_appel_type_text %}<li>{{ equipment }}</li>{% endfor %}
+                {% for equipment in access.get_entree_dispositif_appel_type_text %}<li data-filters="walking">{{ equipment }}</li>{% endfor %}
             {% else %}
-                <li>{{ "entree_dispositif_appel"|positive_text }}</li>
+                <li data-filters="all">{{ "entree_dispositif_appel"|positive_text }}</li>
             {% endif %}
         {% endif %}
         {% if access.entree_pmr %}
-            <li>
+            <li data-filters="all">
                 {{ "entree_pmr"|positive_text }}
                 {% if access.entree_pmr_informations %}
                     :

--- a/templates/erp/includes/access_legal.html
+++ b/templates/erp/includes/access_legal.html
@@ -1,14 +1,14 @@
 {% load a4a %}
 {% load static %}
 {% load i18n %}
-<h4 class="pt-2 h4">
+<h4 class="pt-2 h4" data-filter-title="true">
     <i aria-hidden="true" class="icon icon-paperclip mr-1 larger-font"></i>{% translate "Registre d'accessibilité et conformité" %}
 </h4>
 <ul>
     {% if access.registre_url %}
-        <li>
+        <li data-filters="all">
             {% translate "Registre disponible" %} : <a href="{{ access.registre_url }}">{{ access.registre_url }}</a>
         </li>
     {% endif %}
-    {% if access.conformite %}<li>{{ "conformite"|positive_text }}</li>{% endif %}
+    {% if access.conformite %}<li data-filters="all">{{ "conformite"|positive_text }}</li>{% endif %}
 </ul>

--- a/templates/erp/includes/access_outside_path.html
+++ b/templates/erp/includes/access_outside_path.html
@@ -1,43 +1,47 @@
 {% load a4a %}
 {% load static %}
 {% load i18n %}
-<h4 class="pt-2 h4">
+<h4 class="pt-2 h4" data-filter-title="true">
     <i aria-hidden="true" class="icon icon-road mr-1 larger-font"></i>{% translate "Chemin vers l'entrée" %}
 </h4>
 {% spaceless %}
     <ul>
-        {% if access.has_outside_path_and_no_other_data %}<li>{{ "cheminement_ext_presence"|positive_text }}</li>{% endif %}
-        {% if access.cheminement_ext_bande_guidage %}<li>{{ "cheminement_ext_bande_guidage"|positive_text }}</li>{% endif %}
+        {% if access.has_outside_path_and_no_other_data %}
+            <li data-filters="all">{{ "cheminement_ext_presence"|positive_text }}</li>
+        {% endif %}
+        {% if access.cheminement_ext_bande_guidage %}
+            <li data-filters="visual">{{ "cheminement_ext_bande_guidage"|positive_text }}</li>
+        {% endif %}
         {% if access.cheminement_ext_plain_pied %}
-            <li>{{ "cheminement_ext_plain_pied"|positive_text }}</li>
+            <li data-filters="visual,walking">{{ "cheminement_ext_plain_pied"|positive_text }}</li>
         {% elif access.cheminement_ext_plain_pied is False %}
-            <li>
+            <li data-filters="visual,walking">
                 {% translate "sur le chemin" as extra_context %}
                 {% include "erp/includes/access_stairs.html" with steps_direction=access.get_outside_steps_direction_text nb_steps=access.cheminement_ext_nombre_marches extra_context=extra_context %}
             </li>
         {% endif %}
         {% include "erp/includes/access_steps.html" with nb_marches=access.cheminement_ext_nombre_marches main_courante_data=access.cheminement_ext_main_courante reperage=access.cheminement_ext_reperage_marches %}
         {% if access.has_ramp_exterior_path %}
-            <li>
+            <li data-filters="walking">
                 {% blocktranslate trimmed with sentence="entree_marches_rampe"|positive_text rampe=access.cheminement_ext_rampe %}
                     {{ sentence }} {{ rampe }}
                 {% endblocktranslate %}
             </li>
         {% elif access.cheminement_ext_rampe is False %}
-            <li>{{ "cheminement_ext_rampe"|negative_text }}</li>
+            <li data-filters="walking">{{ "cheminement_ext_rampe"|negative_text }}</li>
         {% endif %}
-        {% if access.cheminement_ext_ascenseur %}<li>{{ "cheminement_ext_ascenseur"|positive_text }}</li>{% endif %}
-        {% render_access_value "cheminement_ext_terrain_stable" access %}
+        {% if access.cheminement_ext_ascenseur %}<li data-filters="walking,understand">{{ "cheminement_ext_ascenseur"|positive_text }}</li>{% endif %}
+        {% render_access_value "cheminement_ext_terrain_stable" access "walking" %}
         {% if access.cheminement_ext_pente_presence %}
             {% if access.cheminement_ext_pente_degre_difficulte %}
                 {% if access.cheminement_ext_pente_longueur %}
-                    <li>
+                    <li data-filters="walking">
                         {% blocktranslate trimmed with longueur=access.cheminement_ext_pente_longueur difficulte=access.cheminement_ext_pente_degre_difficulte %}
                             Présence d'une pente {{ difficulte }} de longueur {{ longueur }}
                         {% endblocktranslate %}
                     </li>
                 {% else %}
-                    <li>
+                    <li data-filters="walking">
                         {% blocktranslate trimmed with difficulte=access.cheminement_ext_pente_degre_difficulte %}
                             Présence d'une pente {{ difficulte }}
                         {% endblocktranslate %}
@@ -45,7 +49,7 @@
                 {% endif %}
             {% else %}
                 {% if access.cheminement_ext_pente_longueur %}
-                    <li>
+                    <li data-filters="walking">
                         {% blocktranslate trimmed with longueur=access.cheminement_ext_pente_longueur %}
                             Présence d'une pente de longueur {{ longueur }}
                         {% endblocktranslate %}
@@ -56,14 +60,14 @@
             {% endif %}
         {% endif %}
         {% if access.has_camber %}
-            <li>
+            <li data-filters="walking">
                 {% blocktranslate trimmed with difficulty=access.cheminement_ext_devers %}
                     Dévers {{ difficulty }}
                 {% endblocktranslate %}
             </li>
         {% elif access.has_camber is False %}
-            <li>{{ "cheminement_ext_devers"|negative_text }}</li>
+            <li data-filters="walking">{{ "cheminement_ext_devers"|negative_text }}</li>
         {% endif %}
-        {% render_access_value "cheminement_ext_retrecissement" access %}
+        {% render_access_value "cheminement_ext_retrecissement" access "walking" %}
     </ul>
 {% endspaceless %}

--- a/templates/erp/includes/access_parking.html
+++ b/templates/erp/includes/access_parking.html
@@ -1,13 +1,13 @@
 {% load a4a %}
 {% load static %}
 {% load i18n %}
-<h4 class="pt-2 h4 hide-if-empty">
+<h4 class="pt-2 h4" data-filter-title="true">
     <i aria-hidden="true" class="icon icon-bus mr-1 larger-font"></i>{% translate "Transport et stationnement" %}
 </h4>
 {% spaceless %}
     <ul>
         {% if access.transport_station_presence %}
-            <li>
+            <li data-filters="all">
                 {{ "transport_station_presence"|positive_text }}
                 {% if access.transport_information %}
                     :
@@ -17,25 +17,25 @@
                 {% endif %}
             </li>
         {% elif access.transport_station_presence is False %}
-            <li>{{ "transport_station_presence"|negative_text }}</li>
+            <li data-filters="all">{{ "transport_station_presence"|negative_text }}</li>
         {% endif %}
         {% if access.stationnement_presence %}
             {% if access.stationnement_pmr %}
-                <li>{{ "stationnement_pmr"|positive_text }}</li>
+                <li data-filters="all">{{ "stationnement_pmr"|positive_text }}</li>
             {% else %}
-                <li>{{ "stationnement_presence"|positive_text }}</li>
+                <li data-filters="all">{{ "stationnement_presence"|positive_text }}</li>
             {% endif %}
         {% elif access.stationnement_presence is False %}
-            <li>{{ "stationnement_presence"|negative_text }}</li>
+            <li data-filters="all">{{ "stationnement_presence"|negative_text }}</li>
         {% endif %}
         {% if access.stationnement_ext_presence %}
             {% if access.stationnement_ext_pmr %}
-                <li>{{ "stationnement_ext_pmr"|positive_text }}</li>
+                <li data-filters="all">{{ "stationnement_ext_pmr"|positive_text }}</li>
             {% else %}
-                <li>{{ "stationnement_ext_presence"|positive_text }}</li>
+                <li data-filters="all">{{ "stationnement_ext_presence"|positive_text }}</li>
             {% endif %}
         {% elif access.stationnement_ext_presence is False %}
-            <li>{{ "stationnement_ext_presence"|negative_text }}</li>
+            <li data-filters="all">{{ "stationnement_ext_presence"|negative_text }}</li>
         {% endif %}
     </ul>
 {% endspaceless %}

--- a/templates/erp/includes/access_reception.html
+++ b/templates/erp/includes/access_reception.html
@@ -1,35 +1,35 @@
 {% load a4a %}
 {% load static %}
 {% load i18n %}
-<h4 class="pt-2 h4">
+<h4 class="pt-2 h4" data-filter-title="true">
     <i aria-hidden="true" class="icon icon-users mr-1 larger-font"></i>{% translate "Accueil et équipement" %}
 </h4>
 {% spaceless %}
     <ul>
-        {% render_access_value "accueil_visibilite" access %}
+        {% render_access_value "accueil_visibilite" access "all" %}
         {% if access.accueil_cheminement_plain_pied %}
-            <li>{{ "accueil_cheminement_plain_pied"|positive_text }}</li>
+            <li data-filters="walking,visual">{{ "accueil_cheminement_plain_pied"|positive_text }}</li>
         {% elif access.accueil_cheminement_plain_pied is False %}
             {% translate "pour atteindre l'accueil" as extra_context %}
-            <li>
+            <li data-filters="walking,visual">
                 {% include "erp/includes/access_stairs.html" with steps_direction=access.get_reception_steps_direction_text nb_steps=access.accueil_cheminement_nombre_marches extra_context=extra_context %}
             </li>
         {% endif %}
         {% include "erp/includes/access_steps.html" with nb_marches=access.accueil_nombre_marches main_courante_data=access.accueil_cheminement_main_courante reperage=access.accueil_cheminement_reperage_marches %}
         {% if access.has_ramp_reception %}
-            <li>
+            <li data-filters="walking">
                 {% blocktranslate trimmed with sentence="entree_marches_rampe"|positive_text rampe=access.accueil_cheminement_rampe %}
                     {{ sentence }} {{ rampe }}
                 {% endblocktranslate %}
             </li>
         {% elif access.accueil_cheminement_rampe is False %}
-            <li>{{ "accueil_cheminement_rampe"|negative_text }}</li>
+            <li data-filters="walking">{{ "accueil_cheminement_rampe"|negative_text }}</li>
         {% endif %}
-        {% if access.accueil_cheminement_ascenseur %}<li>{{ "accueil_cheminement_ascenseur"|positive_text }}</li>{% endif %}
-        {% render_access_value "accueil_retrecissement" access %}
-        {% if access.accueil_personnels %}<li>{{ access.get_accueil_personnels_display }}</li>{% endif %}
+        {% if access.accueil_cheminement_ascenseur %}<li data-filters="walking,understand">{{ "accueil_cheminement_ascenseur"|positive_text }}</li>{% endif %}
+        {% render_access_value "accueil_retrecissement" access "walking" %}
+        {% if access.accueil_personnels %}<li data-filters="all">{{ access.get_accueil_personnels_display }}</li>{% endif %}
         {% if access.accueil_audiodescription_presence %}
-            <li>
+            <li data-filters="visual">
                 {% if access.accueil_audiodescription %}
                     {% blocktranslate trimmed with equipements=access.get_accueil_audiodescription_text %}
                         Audiodescription : {{ equipements }}
@@ -39,25 +39,25 @@
                 {% endif %}
             </li>
         {% elif access.accueil_audiodescription_presence is False %}
-            <li>{{ "accueil_audiodescription_presence"|negative_text }}</li>
+            <li data-filters="visual">{{ "accueil_audiodescription_presence"|negative_text }}</li>
         {% endif %}
         {% if access.accueil_equipements_malentendants_presence %}
             {% if access.accueil_equipements_malentendants %}
                 {% for equipment in access.accueil_equipements_malentendants %}<li>{{ equipment|title }}</li>{% endfor %}
             {% else %}
-                <li>{{ "accueil_equipements_malentendants_presence"|positive_text }}</li>
+                <li data-filters="hearing">{{ "accueil_equipements_malentendants_presence"|positive_text }}</li>
             {% endif %}
         {% elif access.accueil_equipements_malentendants_presence is False %}
-            <li>{{ "accueil_equipements_malentendants_presence"|negative_text }}</li>
+            <li data-filters="hearing">{{ "accueil_equipements_malentendants_presence"|negative_text }}</li>
         {% endif %}
         {% if access.sanitaires_presence %}
             {% if access.sanitaires_adaptes %}
-                <li>{% translate "Toilettes PMR" %}</li>
+                <li data-filters="walking">{% translate "Toilettes PMR" %}</li>
             {% else %}
-                <li>{% translate "Toilettes classiques" %}</li>
+                <li data-filters="walking">{% translate "Toilettes classiques" %}</li>
             {% endif %}
         {% elif access.sanitaires_presence is False %}
-            <li>{{ "sanitaires_presence"|negative_text }}</li>
+            <li data-filters="walking">{{ "sanitaires_presence"|negative_text }}</li>
         {% endif %}
     </ul>
 {% endspaceless %}

--- a/templates/erp/includes/access_steps.html
+++ b/templates/erp/includes/access_steps.html
@@ -39,7 +39,7 @@
     {% endif %}
 {% endif %}
 {% if reperage_marches %}
-    <li>
+    <li data-filters="visual,walking">
         {% if main_courante %}
             {% blocktranslate trimmed with main_courante=main_courante %}
                 {{ reperage_marches }} et {{ main_courante }}

--- a/templates/erp/includes/access_value.html
+++ b/templates/erp/includes/access_value.html
@@ -1,6 +1,6 @@
 {% load a4a %}
 {% if value %}
-    <li>{{ value_name|positive_text }}</li>
+    <li {% if filters %}data-filter="{{ filters }}"{% endif %}>{{ value_name|positive_text }}</li>
 {% elif value is False %}
-    <li>{{ value_name|negative_text }}</li>
+    <li {% if filters %}data-filter="{{ filters }}"{% endif %}>{{ value_name|negative_text }}</li>
 {% endif %}

--- a/templates/erp/includes/filters.html
+++ b/templates/erp/includes/filters.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+<div class="d-flex row p-2">
+    {% translate "Difficulté à voir" as visual_text %}
+    {% translate "Difficulté à marcher" as walking_text %}
+    {% translate "Difficulté à entendre" as deaf_text %}
+    {% translate "Difficulté à comprendre" as understand_text %}
+    {% include "search/tag_with_label.html" with slug="visual" input_name="erp_filter" eventType="filterClicked" name=visual_text icon="diff-vision" %}
+    {% include "search/tag_with_label.html" with slug="walking" input_name="erp_filter" eventType="filterClicked" name=walking_text icon="diff-walking" %}
+    {% include "search/tag_with_label.html" with slug="hearing" input_name="erp_filter" eventType="filterClicked" name=deaf_text icon="deaf" %}
+    {% include "search/tag_with_label.html" with slug="understand" input_name="erp_filter" eventType="filterClicked" name=understand_text icon="diff-understand" %}
+</div>

--- a/templates/erp/index.html
+++ b/templates/erp/index.html
@@ -76,8 +76,9 @@
                 </div>
             {% endif %}
             <div class="d-flex flex-column">
-                <div class="row order-2">
+                <div class="row order-2"  id="filter-controller">
                     <section id="a11y" class="col-lg-7 col-xl-8 remove-title-if-empty">
+                        {% include "erp/includes/filters.html" %}
                         {% include "erp/includes/access_parking.html" %}
                         {% include "erp/includes/access_outside_path.html" %}
                         {% include "erp/includes/access_entrance.html" %}

--- a/templates/search/tag_with_label.html
+++ b/templates/search/tag_with_label.html
@@ -1,16 +1,14 @@
-<span {% if input_name == "equipments" and slug not in params %}class="hidden"{% endif %}>
+<span>
     <input type="checkbox"
            id="{{ slug }}"
            name="{{ input_name }}"
            class="hidden"
-           value="{{ slug }}"
-           {% if slug in params %}checked{% endif %}>
-    <label class="fr-label invisible ml-0" for="{{ slug }}"></label>
-    <button class="fr-tag a4a-label-tag mb-1 {% if icon %}tag-picto tag-picto-{{ icon }}{% endif %} fr-tag--icon-left {% if is_default_suggestion %}default-suggestion{% endif %}"
+           autocomplete="off"
+           value="{{ slug }}">
+    <label class="fr-label ml-0" for="{{ slug }}"></label>
+    <button class="fr-tag a4a-label-tag mb-1 mr-2 {% if icon %}tag-picto tag-picto-{{ icon }}{% endif %} fr-tag--icon-left"
             aria-pressed="{% if slug in params %}true{% else %}false{% endif %}"
             data-fr-js-toggle="true"
             type="button"
-            data-event-type="{{ eventType }}"
-            {% if children_list %}data-children="{{ children_list }}"{% endif %}
-            {% if suggestions_list %}data-suggestions="{{ suggestions_list }}"{% endif %}>{{ name }}</button>
+            data-event-type="{{ eventType }}">{{ name }}</button>
 </span>


### PR DESCRIPTION
Add the possibility for the user to filter on one or multiple types of handicap. By doing so we only display the data we think is appropriate for this type of handicap.

- Re-use tag_with_label.html which was not used in the code
- Implement filters with icons and JavaScript logic
- Add the type of handicap on all the data of the page (all the <li> tags)