### PR TITLE
Show verbose text for dispositif appel type

### DIFF
--- a/erp/models.py
+++ b/erp/models.py
@@ -1709,9 +1709,19 @@ class Accessibilite(models.Model):
         )
 
     def get_labels_display(self):
+        if not self.labels:
+            return
         label_to_text = {k: str(v) for k, v in schema.LABEL_CHOICES}
         return [(label, label_to_text.get(label)) for label in self.labels]
 
     def get_accueil_audiodescription_text(self):
+        if not self.accueil_audiodescription:
+            return
         equipment_to_text = {k: str(v) for k, v in schema.AUDIODESCRIPTION_CHOICES}
         return ",".join([equipment_to_text.get(equipment) for equipment in self.accueil_audiodescription])
+
+    def get_entree_dispositif_appel_type_text(self):
+        if not self.entree_dispositif_appel_type:
+            return
+        equipment_to_text = {k: str(v) for k, v in schema.DISPOSITIFS_APPEL_CHOICES}
+        return [equipment_to_text.get(equipment) for equipment in self.entree_dispositif_appel_type]

--- a/templates/erp/includes/access_entrance.html
+++ b/templates/erp/includes/access_entrance.html
@@ -68,7 +68,7 @@
         {% if access.entree_aide_humaine %}<li>{{ "entree_aide_humaine"|positive_text }}</li>{% endif %}
         {% if access.entree_dispositif_appel %}
             {% if access.entree_dispositif_appel_type %}
-                {% for equipment in access.entree_dispositif_appel_type %}<li>{{ equipment|title }}</li>{% endfor %}
+                {% for equipment in access.get_entree_dispositif_appel_type_text %}<li>{{ equipment }}</li>{% endfor %}
             {% else %}
                 <li>{{ "entree_dispositif_appel"|positive_text }}</li>
             {% endif %}


### PR DESCRIPTION
Show the verbose text instead of the database value for `entree_dispositif_appel_type`. This makes the display more explicit.