### PR TITLE
Fix helper function when unknown value

### DIFF
--- a/erp/models.py
+++ b/erp/models.py
@@ -1692,6 +1692,8 @@ class Accessibilite(models.Model):
         return self.accueil_cheminement_rampe and self.accueil_cheminement_rampe != schema.RAMPE_AUCUNE
 
     def _get_steps_direction_text(self, nb_steps, direction):
+        if not nb_steps:
+            return
         if direction == schema.ESCALIER_MONTANT:
             return ngettext("montante", "montantes", nb_steps)
         if direction == schema.ESCALIER_DESCENDANT:

--- a/tests/erp/test_models.py
+++ b/tests/erp/test_models.py
@@ -306,3 +306,22 @@ def test_merge_cant_handle_conflicting_values():
 
     a_erp.refresh_from_db()
     assert a_erp.accessibilite.stationnement_presence is False
+
+
+@pytest.mark.django_db
+def test_get_outside_steps_direction_text():
+    access = AccessibiliteFactory(cheminement_ext_nombre_marches=10, cheminement_ext_sens_marches="montant")
+
+    assert access.get_outside_steps_direction_text() == "montantes"
+
+    access.cheminement_ext_nombre_marches = 1
+    access.save()
+    assert access.get_outside_steps_direction_text() == "montante"
+
+    access.cheminement_ext_nombre_marches = None
+    access.save()
+    assert access.get_outside_steps_direction_text() is None
+
+    access.cheminement_ext_nombre_marches = 0
+    access.save()
+    assert access.get_outside_steps_direction_text() is None


### PR DESCRIPTION
Make sure always return a value for steps direction even when the number of steps is not known.