### PR TITLE
Create revision when a user confirms ERP

### DIFF
--- a/core/lib/text.py
+++ b/core/lib/text.py
@@ -1,3 +1,4 @@
+import datetime
 import random
 import string
 import unicodedata
@@ -49,6 +50,8 @@ def humanize_value(value, choices=None):
         value = "Non"
     elif isinstance(value, (int, float)):
         value = str(value)
+    elif isinstance(value, datetime.datetime):
+        value = value.strftime("%Y-%m-%d à %H:%M")
     else:
         raise NotImplementedError("Type of value isn't recognized : %s" % type(value))
 

--- a/erp/views.py
+++ b/erp/views.py
@@ -446,8 +446,7 @@ def confirm_up_to_date(request, erp_slug):
     if not request.method == "POST":
         return redirect(erp.get_absolute_url())
 
-    erp.checked_up_to_date_at = datetime.datetime.now()
-    erp.save()
+    erp.confirm_up_to_date(request.user)
     messages.add_message(request, messages.SUCCESS, translate("Merci de votre contribution."))
     return redirect(erp.get_absolute_url())
 

--- a/tests/erp/test_browser.py
+++ b/tests/erp/test_browser.py
@@ -7,6 +7,7 @@ from django.contrib.auth.models import User
 from django.contrib.gis.geos import Point
 from django.test import Client
 from django.urls import reverse
+from reversion.models import Version
 
 from compte.models import UserStats
 from erp.models import Accessibilite, Activite, ActivitySuggestion, Erp
@@ -972,6 +973,7 @@ def test_get_erp_by_uuid(client):
 @pytest.mark.django_db
 def test_can_update_checked_up_to_date_at_from_erp(client):
     erp = ErpFactory(published=True)
+    assert Version.objects.get_for_object(erp).count() == 0
 
     assert erp.checked_up_to_date_at is None
 
@@ -981,6 +983,7 @@ def test_can_update_checked_up_to_date_at_from_erp(client):
 
     erp.refresh_from_db()
     assert erp.checked_up_to_date_at is not None
+    assert Version.objects.get_for_object(erp).count() == 1
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Create a revision when a user confirms ERP is up to date via the up to date button on the ERP page.

- Move the logic to the model to make sure is can be re-used
- Adapt the logic of the _get_history function. Some fields where not displayed because the type was not handle in the text library. I had to add the datetime type and added the other datetime to the exclude_fields parameter to make sure we dont see updated_at in the history
- Add check for the number of revisions in the test