### PR TITLE
Improve accessibility of widget for screen readers

### DIFF
--- a/static/js/widget.js
+++ b/static/js/widget.js
@@ -27,7 +27,6 @@
 
   function closeModal(dialog, trigger) {
     dialog.setAttribute('aria-hidden', true)
-    dialog.parentNode.setAttribute('aria-hidden', false)
 
     // restoring focus
     if (trigger) {
@@ -65,7 +64,6 @@
     const lastFocusableElement = focusableElements[focusableElements.length - 1]
 
     dialog.setAttribute('aria-hidden', false)
-    dialog.parentNode.setAttribute('aria-hidden', true)
 
     // return if no focusable element
     if (!firstFocusableElement) {
@@ -214,8 +212,7 @@
           bodyDom.appendChild(newDiv)
 
           let dialogModal = newDiv.querySelector('#dialog')
-          dialogModal.setAttribute('aria-hidden', true)
-          dialogModal.parentNode.setAttribute('aria-hidden', true)
+          dialogModal.setAttribute('aria-hidden', false)
 
           const dismissTrigger = dialogModal.querySelector('[data-dismiss]')
           dismissTrigger.addEventListener('click', (event) => {

--- a/templates/erp/widget/index.html
+++ b/templates/erp/widget/index.html
@@ -14,30 +14,29 @@
                                  src="{{ data.icon }}"
                                  style="width:40px"
                                  alt="{{ data.label }}">
-                        </img>
-                    </div>
-                    <div class="fr-col-md-10 modal__text">
-                        <span class="fr-text--heavy">{{ item|capfirst }}</span>
-                        <br>
-                        <span style="color: #3A3A3A;">{{ data.label|linebreaks }}</span>
-                    </div>
-                </li>
-                {% if not forloop.last %}<hr class="modal__hr">{% endif %}
-            {% endfor %}
-        </ul>
-    {% endif %}
-    <p class="modal__footer_link">
-        <a id="btn_acceslibre"
-           href="{{ erp.get_absolute_uri }}"
-           target="_blank"
-           rel="noopener"
-           class="fr-btn fr-btn--secondary fr-text--md btn_acceslibre">
-            <span>{% translate "Voir plus sur" %}</span>
-            <img src="{{ base_url }}{% static 'img/logo-acceslibre-widget.png' %}"
-                 alt="acceslibre"
-                 style="height:50px;
-                        vertical-align: text-bottom">
-        </a>
-    </p>
-</div>
+                        </div>
+                        <div class="fr-col-md-10 modal__text">
+                            <span class="fr-text--heavy">{{ item|capfirst }}</span>
+                            <br>
+                            <span style="color: #3A3A3A;">{{ data.label|linebreaks }}</span>
+                        </div>
+                    </li>
+                    {% if not forloop.last %}<hr class="modal__hr" aria-hidden="true">{% endif %}
+                {% endfor %}
+            </ul>
+        {% endif %}
+        <p class="modal__footer_link">
+            <a id="btn_acceslibre"
+               href="{{ erp.get_absolute_uri }}"
+               target="_blank"
+               rel="noopener"
+               class="fr-btn fr-btn--secondary fr-text--md btn_acceslibre">
+                <span>{% translate "Voir plus sur" %}</span>
+                <img src="{{ base_url }}{% static 'img/logo-acceslibre-widget.png' %}"
+                     alt="acceslibre"
+                     style="height:50px;
+                            vertical-align: text-bottom">
+            </a>
+        </p>
+    </div>
 {% endblock modal_content %}


### PR DESCRIPTION
It looks like the content of the widget was not read by screen readers,
this commits tries to fix this.

All my tests were done using Orca and Chromium, for both a classic
widget and a "controlled" widget. For each test I tried to read the
heading (shortcut `h` for Orca) and the content of the modal (down arrow
to read line per line using Orca).

The main problem this commits fixes is that all the content of the
widget was inside a div with the `aria-hidden` set to true, even if the
content itself (nested inside this div) had `aria-hidden`set to false,
it looks like screen-readers won't consider the content in this case.
I did not found a clear answer on whether nested `aria-hidden` are valid
or not, but considered it is probably a bad idea anyway. Using my test
setup (I guess support can vary with other softwares / configuration),
nested aria attributes are just ignored and all the content is skipped
if the parent div has an `aria-hidden` attribute set to true.

This commits also fixes an image tag, and hide horizontals rules (hr)
elements for screen readers (the structure of the html should be
enough).

- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden
- https://stackoverflow.com/questions/21828152/nested-aria-hidden (no
  source)