### PR TITLE
Implement incremental challenge scores computation.

### DIFF
--- a/erp/management/commands/start_scheduler.py
+++ b/erp/management/commands/start_scheduler.py
@@ -94,9 +94,7 @@ class Command(BaseCommand):
                 call_command(task["command"], **task["command_args"])
 
     def setup(self):
-        for hour in ("00:00", "12:00"):
-            schedule.every().day.at(hour).do(call_command, "refresh_stats")
-
+        schedule.every().day.at("04:00").do(call_command, "refresh_stats")
         schedule.every().day.at("03:35").do(call_command, "purge_obsolete_objects_in_base")
         schedule.every().day.at("03:55").do(call_command, "deleterevisions", keep=20, days=70)
         schedule.every().day.at("05:10").do(call_command, "import_dataset", "gendarmerie")

--- a/erp/views.py
+++ b/erp/views.py
@@ -138,7 +138,7 @@ def challenge_ddt(request):
             "start_date": challenge.start_date,
             "stop_date": challenge.end_date,
             "today": today,
-            "top_contribs": challenge.classement,
+            "top_contribs": challenge.get_classement(),
             "total_contributions": challenge.nb_erp_total_added,
         },
     )
@@ -155,7 +155,7 @@ def challenge_detail(request, challenge_slug=None):
             "start_date": challenge.start_date,
             "stop_date": challenge.end_date,
             "today": today,
-            "top_contribs": challenge.classement,
+            "top_contribs": challenge.get_classement(),
             "total_contributions": challenge.nb_erp_total_added,
         },
     )

--- a/stats/management/commands/refresh_stats.py
+++ b/stats/management/commands/refresh_stats.py
@@ -1,8 +1,9 @@
-import datetime
 import logging
+from datetime import timedelta
 
 from django.core.management import BaseCommand, CommandError
 from django.db.models import Q
+from django.utils import timezone
 
 from stats.models import Challenge, GlobalStats
 
@@ -20,13 +21,14 @@ class Command(BaseCommand):
             raise CommandError("Interrompu.")
 
         # Compute challenges stats
-        today = datetime.datetime.today()
+        today = timezone.now().date()
+        yesterday = today - timedelta(days=1)
 
         for challenge in Challenge.objects.filter(
             Q(
                 start_date__gt=today,
             )
-            | Q(start_date__lte=today, end_date__gt=today)
+            | Q(start_date__lte=today, end_date__gt=yesterday)  # We compute figures for day D-1
         ):
             try:
                 challenge.refresh_stats()

--- a/stats/queries.py
+++ b/stats/queries.py
@@ -86,7 +86,7 @@ def get_challenge_scores(challenge, start_date, stop_date, player_ids):
         )
         .order_by("revision__date_created")
     )
-    for version in versions:
+    for version in versions.iterator():
         user_id = version.revision.user_id
         previous = get_previous_version(version)
         scores_per_user_id[user_id] += _get_score(version, previous)
@@ -94,8 +94,5 @@ def get_challenge_scores(challenge, start_date, stop_date, player_ids):
     for sub in challenge.inscriptions.all():
         if sub.team_id:
             scores_per_team_id[sub.team_id] += scores_per_user_id.get(sub.player_id) or 0
-
-    scores_per_user_id = sorted(scores_per_user_id.items(), key=lambda k_v: k_v[1], reverse=True)
-    scores_per_team_id = sorted(scores_per_team_id.items(), key=lambda k_v: k_v[1], reverse=True)
 
     return scores_per_user_id, scores_per_team_id

--- a/templates/challenge/detail_v2.html
+++ b/templates/challenge/detail_v2.html
@@ -116,10 +116,10 @@
                     <li>{{ top_contrib.username }} ({{ top_contrib.nb_access_info_changed }})</li>
                 {% endfor %}
             </ol>
-            {% if challenge.classement_team %}
+            {% if challenge.get_classement_team %}
                 <h3 class="mt-5 mb-3">{% translate "Classement par équipe" %}</h3>
                 <ol>
-                    {% for top_contrib in challenge.classement_team %}
+                    {% for top_contrib in challenge.get_classement_team %}
                         <li>{{ top_contrib.team }} ({{ top_contrib.nb_access_info_changed }})</li>
                     {% endfor %}
                 </ol>

--- a/tests/stats/test_challenges.py
+++ b/tests/stats/test_challenges.py
@@ -1,6 +1,9 @@
+from datetime import datetime, timedelta
+
 import pytest
 import reversion
 from django.core.management import call_command
+from reversion.models import Revision
 
 from erp.schema import get_nullable_bool_fields
 from tests.factories import ChallengeFactory, ChallengeTeamFactory, ErpFactory, UserFactory
@@ -9,7 +12,9 @@ from tests.factories import ChallengeFactory, ChallengeTeamFactory, ErpFactory, 
 @pytest.fixture()
 def challenge():
     players = [UserFactory(), UserFactory()]
-    yield ChallengeFactory(players=players)
+    yesterday = datetime.now() - timedelta(days=2)
+    tomorrow = datetime.now() + timedelta(days=1)
+    yield ChallengeFactory(players=players, start_date=yesterday, end_date=tomorrow)
 
 
 class TestChallenge:
@@ -27,6 +32,9 @@ class TestChallenge:
 
             erp.accessibilite.save()
 
+        yesterday = datetime.now() - timedelta(days=1)
+        Revision.objects.all().update(date_created=yesterday)
+
     @pytest.mark.django_db
     def test_nominal_case(self, challenge):
         erp1, erp2 = [
@@ -42,11 +50,12 @@ class TestChallenge:
         call_command("refresh_stats")
 
         challenge.refresh_from_db()
-        assert challenge.classement == [
+
+        assert challenge.get_classement() == [
             {"username": player2.username, "nb_access_info_changed": 3},
             {"username": player1.username, "nb_access_info_changed": 2},
         ]
-        assert not challenge.classement_team
+        assert not challenge.get_classement_team()
 
         team = ChallengeTeamFactory()
 
@@ -56,4 +65,4 @@ class TestChallenge:
         call_command("refresh_stats")
 
         challenge.refresh_from_db()
-        assert not challenge.classement_team == [{"team": team.name, "nb_access_info_changed": 2}]
+        assert not challenge.get_classement_team() == [{"team": team.name, "nb_access_info_changed": 2}]


### PR DESCRIPTION
Implement incremental computation for the challenges' scores. Compute figures for day D-1, daily.
I am a firefighter, so don't blame me :pray: . This code is far from perfect, and the initial model structure, along with maintaining two versions, doesn't help matters.
Currently, in prod, the refresh_stats for the DDT DEAL 2024 challenge is taking approximately 40 minutes to compute all scores (started ~17 days ago).

In `classement` and `classement_team` we are now storing a indexed by day structure. Every day we append the computation for day D-1.

getters have been implemented to keep the old structure we had and to perform a sort by score.