### PR TITLE
Hide empty section on ERP page for old browsers

### DIFF
--- a/static/js/ui/FilterData.js
+++ b/static/js/ui/FilterData.js
@@ -8,18 +8,18 @@ function hasVisibleChildren(element) {
   return visibleChildren
 }
 
-function filterData(root) {
+function listenToFilterClicked(root) {
   const dataToToogle = root.querySelectorAll('[data-filters]')
   document.addEventListener('filterClicked', () => {
     const inputFilters = document.querySelectorAll('[name=erp_filter]:checked')
     const activeFilters = Array.from(inputFilters).map((filter) => filter.value)
-    const titlesToToogle = root.querySelectorAll('[data-filter-title]')
+    const titlesToToggle = root.querySelectorAll('[data-filter-title]')
 
     if (activeFilters.length === 0) {
       dataToToogle.forEach((element) => {
         element.classList.remove('hidden')
       })
-      titlesToToogle.forEach((element) => {
+      titlesToToggle.forEach((element) => {
         element.classList.remove('hidden')
       })
       return
@@ -36,15 +36,25 @@ function filterData(root) {
       }
     })
 
-    titlesToToogle.forEach((titleElement) => {
-      const shouldBeVisible = hasVisibleChildren(titleElement.nextElementSibling)
-      if (shouldBeVisible === true) {
-        titleElement.classList.remove('hidden')
-      } else {
-        titleElement.classList.add('hidden')
-      }
-    })
+    hideEmptyTitles(root)
   })
+}
+
+function hideEmptyTitles(root) {
+  const titlesToToggle = root.querySelectorAll('[data-filter-title]')
+  titlesToToggle.forEach((titleElement) => {
+    const shouldBeVisible = hasVisibleChildren(titleElement.nextElementSibling)
+    if (shouldBeVisible === true) {
+      titleElement.classList.remove('hidden')
+    } else {
+      titleElement.classList.add('hidden')
+    }
+  })
+}
+
+function filterData(root) {
+  hideEmptyTitles(root)
+  listenToFilterClicked(root)
 }
 
 export default filterData


### PR DESCRIPTION
The `has(+ ul:empty)` CSS rule is not handled properly on old browsers (including those used in the french administration) so we are adding this JavaScript logic to hide the title when needed. I am also leaving the CSS rule is anyone don't want to use the JavaScript but has a decent browser.