### PR TITLE
Improve label display for "Autres" labels

### DIFF
--- a/erp/models.py
+++ b/erp/models.py
@@ -1898,3 +1898,13 @@ class Accessibilite(models.Model):
             text += schema.FIELDS["accueil_chambre_douche_barre_appui"]["help_text_ui_neg_v2"].lower()
 
         return text if text != translate_lazy("Douche") else None
+
+    def get_labels_display_text(self):
+        results = []
+        for k, v in self.get_labels_display():
+            if k == schema.LABEL_AUTRE:
+                if self.labels_autre:
+                    results.append((k, self.labels_autre))
+            else:
+                results.append((k, v))
+        return results

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-22 13:04+0200\n"
+"POT-Creation-Date: 2024-05-28 14:31+0200\n"
 "PO-Revision-Date: 2024-04-30 17:38+0200\n"
 "Last-Translator: Marie-Laure3 Vernay <mlvernay@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4627,6 +4627,10 @@ msgid ""
 msgstr ""
 "There is no change history yet for the accessibility data for this facility."
 
+#, python-format
+msgid "Label %(name)s"
+msgstr "Label %(name)s"
+
 msgid "Une personne inspectant des données à la loupe"
 msgstr ""
 
@@ -4733,10 +4737,6 @@ msgstr "Accessibility information"
 #, python-format
 msgid "- mises à jour le %(date)s"
 msgstr "- updated on %(date)s"
-
-#, python-format
-msgid "Label %(name)s"
-msgstr "Label %(name)s"
 
 msgid "Fermer la fenêtre"
 msgstr "Close the window"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-22 13:04+0200\n"
+"POT-Creation-Date: 2024-05-28 14:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4169,6 +4169,9 @@ msgid ""
 "d'accessibilité de cet établissement."
 msgstr ""
 
+#, python-format
+msgid "Label %(name)s"
+msgstr ""
 
 msgid "Une personne inspectant des données à la loupe"
 msgstr ""
@@ -4275,11 +4278,6 @@ msgstr ""
 #, python-format
 msgid "- mises à jour le %(date)s"
 msgstr ""
-
-#, python-format
-msgid "Label %(name)s"
-msgstr ""
-
 
 msgid "Fermer la fenêtre"
 msgstr ""

--- a/templates/erp/includes/labels.html
+++ b/templates/erp/includes/labels.html
@@ -1,0 +1,28 @@
+{% load a4a %}
+{% load static %}
+{% load i18n %}
+<div class="fr-grid-row fr-grid-row--gutters mb-2 labels">
+    {% for value, label in access.get_labels_display_text %}
+        <div class="fr-col fr-col-md-4">
+            <div class="fr-card p-2 fr-card--horizontal">
+                <div class="fr-card__body">
+                    <p class="my-auto">
+                        {% blocktranslate trimmed with name=label %}
+                            Label {{ name }}
+                        {% endblocktranslate %}
+                        {% if value == "th" and th_labels %}
+                            {% if th_labels %}{{ th_labels|join:", " }}{% endif %}
+                        {% endif %}
+                    </p>
+                </div>
+                {% if label|label_to_image %}
+                    <div class="fr-card__header d-flex align-items-center">
+                        <img class="fr-responsive-img"
+                             src="{{ label|label_to_image }}"
+                             alt="Logo {{ label }}" />
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+    {% endfor %}
+</div>

--- a/templates/erp/index.html
+++ b/templates/erp/index.html
@@ -51,29 +51,7 @@
                 {% endif %}
             </div>
             {% if access.labels %}
-                <div class="fr-grid-row fr-grid-row--gutters mb-2 labels">
-                    {% for value, label in access.get_labels_display %}
-                        <div class="fr-col fr-col-md-4">
-                            <div class="fr-card p-2 fr-card--horizontal">
-                                <div class="fr-card__body">
-                                    <p class="my-auto">
-                                        {% blocktranslate trimmed with name=label %}
-                                            Label {{ name }}
-                                        {% endblocktranslate %}
-                                        {% if value == "th" and th_labels %}
-                                            {% if th_labels %}{{ th_labels|join:", " }}{% endif %}
-                                        {% endif %}
-                                    </p>
-                                </div>
-                                <div class="fr-card__header d-flex align-items-center">
-                                    <img class="fr-responsive-img"
-                                         src="{{ label|label_to_image }}"
-                                         alt="Logo {{ label }}" />
-                                </div>
-                            </div>
-                        </div>
-                    {% endfor %}
-                </div>
+                {% include "erp/includes/labels.html" %}
             {% endif %}
             <div class="d-flex flex-column">
                 <div class="row order-2"  id="filter-controller">


### PR DESCRIPTION
- Don't show the "Autres" if we don't have the name of the label
- When we have the name, don't try to show an image