### PR TITLE
Fix issue with Sentry initialization

### DIFF
--- a/templates/common/sentry.html
+++ b/templates/common/sentry.html
@@ -1,16 +1,16 @@
 {% if not debug and SENTRY_DSN %}
     <!-- Sentry -->
     <script>
-  (function(Sentry, Integrations) {
+  (function(Sentry) {
     if (!Sentry) {
       return;
     }
     Sentry.init({
       dsn: "{{ SENTRY_DSN }}",
       environment: "{% if STAGING %}recette{% else %}production{% endif %}",
-      integrations: [new Integrations.BrowserTracing()],
+      integrations: [Sentry.browserTracingIntegration()],
     });
-  })(window.Sentry, window.SentryIntegrations);
+  })(window.Sentry);
     </script>
     <!-- End Sentry Code -->
 {% endif %}


### PR DESCRIPTION
This commit will fix our frontend integration with Sentry. This was not spotted earlier as Sentry is not used for local env.

I am not sure when this issue was introduced but I made the changes following the releases notes of the version 8.0.0. I also used the documentation as an extra reference to make sure this change was intended. This was also documented in the migration guide.

https://github.com/getsentry/sentry-javascript/releases/tag/8.0.0
https://docs.sentry.io/platforms/javascript/performance/#configure https://github.com/getsentry/sentry-javascript/blob/8.0.0/MIGRATION.md#removal-of-class-based-integrations