### PR TITLE
Add Django admin to CSP_EXCLUDE_URL_PREFIXES

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -53,7 +53,7 @@ CSP_DEFAULT_SRC = (
     "wss://stream.relay.crisp.chat",
 )
 
-CSP_EXCLUDE_URL_PREFIXES = ("/api",)  # swagger uses scripts from remote cdns
+CSP_EXCLUDE_URL_PREFIXES = ("/api", "/admin")  # swagger and admin uses scripts from remote cdns
 
 # Maps
 MAP_SEARCH_RADIUS_KM = 10


### PR DESCRIPTION
With the introduction of CSP the Django Admin of the ERPs was not loading properly anymore. This is due to `GeoModelAdmin` loading a JavaScript file from Cloudflare (see `openlayers_url`).

From there I had 3 options:
- Self host the JS file and override the class. I did not choose this option as it will make the maintenance of this code very hard. The admin could break any time and we will need to update the JS file manualy.
- Add the `cdnjs.cloudflare.com` domain to the allowed CSP list, which seems dangerous as it is very easy to updload a file that could be dangereous on this domain.
- Disable the CSP on the Django admin. I picked this option, the probability of having a XSS in the admin is pretty low and the attack would be very hard (few people have access to the admin, hard for the attacker to find the vuln and test it).