### PR TITLE
Allow to revert changes made by one user

### DIFF
--- a/erp/management/commands/cancel_user_modifications.py
+++ b/erp/management/commands/cancel_user_modifications.py
@@ -1,0 +1,68 @@
+from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
+from django.core.management.base import BaseCommand
+from reversion.models import Version
+
+from erp.models import Accessibilite, Erp
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument("username")
+        parser.add_argument(
+            "--write",
+            action="store_true",
+            help="Actually edit the database",
+        )
+
+    def _revert_changes_on_erp(self, user):
+        erp_content_type = ContentType.objects.get_for_model(Erp)
+        erp_versions_by_user = Version.objects.filter(revision__user=user, content_type=erp_content_type)
+        erp_ids = list(erp_versions_by_user.values_list("object_id", flat=True))
+        erp_edited_by_user = Erp.objects.filter(id__in=erp_ids)
+        print(f"ERP edited by user {erp_edited_by_user.count()}")
+
+        access_content_type = ContentType.objects.get_for_model(Accessibilite)
+        access_versions_by_user = Version.objects.filter(revision__user=user, content_type=access_content_type)
+        access_ids = list(access_versions_by_user.values_list("object_id", flat=True))
+        erp_access_edited_by_user = Erp.objects.filter(accessibilite__id__in=access_ids)
+        print(f"ERP (via access) edited by user: {erp_access_edited_by_user.count()}")
+
+        erps = set(erp_edited_by_user | erp_access_edited_by_user)
+        print(f"Total number of ERPs with modifications from the user: {len(erps)}")
+
+        to_revert = 0
+        for erp in erps:
+            history = erp.get_history()
+            if not history:
+                continue
+
+            last_entry = history[0]
+            if last_entry["user"] != user:
+                continue
+
+            if erp.checked_up_to_date_at and last_entry["date"] < erp.checked_up_to_date_at:
+                continue
+
+            list_of_good_entries = [h for h in history if h["user"] != user]
+            if list_of_good_entries:
+                to_revert += 1
+                if self.should_write:
+                    list_of_good_entries[0]["revision"].revert()
+                else:
+                    print(f"Would have reverted {list_of_good_entries[0]['revision']}")
+
+        print(f"Will have reverted {to_revert} revisions")
+
+    def handle(self, *args, **options):
+        self.should_write = options["write"]
+        username = options["username"]
+        try:
+            user = User.objects.get(username__icontains=username)
+        except User.DoesNotExist:
+            self.stderr.write(f"User with username {username} not found")
+            return
+        self._revert_changes_on_erp(user)
+
+
+# TODO change tests

--- a/erp/models.py
+++ b/erp/models.py
@@ -73,6 +73,7 @@ def _get_history(versions, exclude_fields=None, exclude_changes_from=None):
                     "date": version.revision.date_created,
                     "comment": version.revision.get_comment(),
                     "diff": [entry for entry in final_diff if entry["field"] not in exclude_fields],
+                    "revision": version.revision,
                 },
             )
         current_fields_dict = fields

--- a/tests/erp/test_cancel_user_modifications.py
+++ b/tests/erp/test_cancel_user_modifications.py
@@ -1,0 +1,108 @@
+import pytest
+import reversion
+from django.core.management import call_command
+from django.urls import reverse
+
+from erp.models import Erp
+from tests.factories import ErpFactory, UserFactory
+
+
+@pytest.mark.django_db
+def test_will_revert_user_changes(django_app):
+    with reversion.create_revision():
+        erp = ErpFactory(with_accessibilite=True)
+    assert Erp.objects.count() == 1
+
+    good_user = UserFactory()
+    response = django_app.get(reverse("contrib_transport", kwargs={"erp_slug": erp.slug}), user=good_user)
+    form = response.forms[1]
+    form["transport_station_presence"].value = "True"
+    form["transport_information"] = "Pas loin du métro république"
+    form.submit("Publier")
+
+    bad_user = UserFactory()
+    response = django_app.get(reverse("contrib_transport", kwargs={"erp_slug": erp.slug}), user=bad_user)
+    form = response.forms[1]
+    form["transport_station_presence"].value = "False"
+    form["transport_information"] = ""
+    form.submit("Publier")
+
+    erp.refresh_from_db()
+    assert erp.accessibilite.transport_station_presence is False
+    assert erp.accessibilite.transport_information == ""
+
+    # Dry run
+    call_command("cancel_user_modifications", bad_user.username, write=False)
+    erp = Erp.objects.get()
+    assert erp.accessibilite.transport_station_presence is False
+    assert erp.accessibilite.transport_information == ""
+
+    # Real run
+    call_command("cancel_user_modifications", bad_user.username, write=True)
+    erp = Erp.objects.get()
+    assert erp.accessibilite.transport_station_presence is True
+    assert erp.accessibilite.transport_information == "Pas loin du métro république"
+
+
+@pytest.mark.django_db
+def test_will_not_revert_user_changes_when_edited(django_app):
+    erp = ErpFactory(with_accessibilite=True)
+    assert Erp.objects.count() == 1
+
+    good_user = UserFactory()
+    response = django_app.get(reverse("contrib_transport", kwargs={"erp_slug": erp.slug}), user=good_user)
+    form = response.forms[1]
+    form["transport_station_presence"].value = "True"
+    form["transport_information"] = "Pas loin du métro république"
+    form.submit("Publier")
+
+    bad_user = UserFactory()
+    response = django_app.get(reverse("contrib_transport", kwargs={"erp_slug": erp.slug}), user=bad_user)
+    form = response.forms[1]
+    form["transport_station_presence"].value = "False"
+    form["transport_information"] = ""
+    form.submit("Publier")
+
+    good_user = UserFactory()
+    response = django_app.get(reverse("contrib_transport", kwargs={"erp_slug": erp.slug}), user=good_user)
+    form = response.forms[1]
+    form["transport_station_presence"].value = "True"
+    form["transport_information"] = "Pas loin du métro république"
+    form.submit("Publier")
+
+    erp.refresh_from_db()
+    assert erp.accessibilite.transport_station_presence is True
+    assert erp.accessibilite.transport_information == "Pas loin du métro république"
+
+    call_command("cancel_user_modifications", bad_user.username, write=True)
+    erp = Erp.objects.get()
+    assert erp.accessibilite.transport_station_presence is True
+    assert erp.accessibilite.transport_information == "Pas loin du métro république"
+
+
+@pytest.mark.django_db
+def test_will_not_revert_user_changes_when_confirmed(django_app):
+    erp = ErpFactory(with_accessibilite=True)
+    assert Erp.objects.count() == 1
+
+    good_user = UserFactory()
+    response = django_app.get(reverse("contrib_transport", kwargs={"erp_slug": erp.slug}), user=good_user)
+    form = response.forms[1]
+    form["transport_station_presence"].value = "True"
+    form["transport_information"] = "Pas loin du métro république"
+    form.submit("Publier")
+
+    bad_user = UserFactory()
+    response = django_app.get(reverse("contrib_transport", kwargs={"erp_slug": erp.slug}), user=bad_user)
+    form = response.forms[1]
+    form["transport_station_presence"].value = "False"
+    form["transport_information"] = ""
+    form.submit("Publier")
+
+    erp.confirm_up_to_date(user=None)
+    erp.refresh_from_db()
+
+    call_command("cancel_user_modifications", bad_user.username, write=True)
+    erp = Erp.objects.get()
+    assert erp.accessibilite.transport_station_presence is False
+    assert erp.accessibilite.transport_information == ""

--- a/tests/subscription/test_commands.py
+++ b/tests/subscription/test_commands.py
@@ -7,6 +7,7 @@ from reversion.models import Version
 from erp.models import Erp
 from subscription.models import ErpSubscription
 from tests.factories import ActiviteFactory, CommuneFactory, ErpFactory, UserFactory
+from unittest.mock import ANY
 
 
 @pytest.fixture
@@ -141,6 +142,7 @@ def test_notification_erp(mocker, mock_geocode, client):
                     "changes_by_others": [
                         {
                             "user": "sophie",
+                            "revision": ANY,
                             "comment": "",
                             "diff": [
                                 {
@@ -153,6 +155,7 @@ def test_notification_erp(mocker, mock_geocode, client):
                         },
                         {
                             "user": "sophie",
+                            "revision": ANY,
                             "comment": "",
                             "diff": [
                                 {"field": "nom", "old": "niko erp", "new": "sophie erp", "label": "nom"},
@@ -211,6 +214,7 @@ def test_notification_accessibilite(client, mocker):
                     "changes_by_others": [
                         {
                             "user": "sophie",
+                            "revision": ANY,
                             "comment": "",
                             "diff": [
                                 {


### PR DESCRIPTION
Add a command to revert the changes made by one user if:
- The ERP was not "confirmed up to date" in the meantine
- No other revision more recently