### PR TITLE
Make link in warning more visible

### DIFF
--- a/erp/forms.py
+++ b/erp/forms.py
@@ -482,7 +482,7 @@ class PublicErpAdminInfosForm(BasePublicErpInfosForm):
 
             if existing:
                 if existing.published:
-                    erp_display = f'<a href="{existing.get_absolute_url()}">{activite} - {adresse}</a>'
+                    erp_display = f'<a href="{existing.get_absolute_url()}" target="_blank" class="fr-link">{activite} - {adresse}</a>'
                 else:
                     erp_display = f"{activite} - {adresse}"
                 raise ValidationError(


### PR DESCRIPTION
Make sure we make the link in the warning box more visible when an ERP already exists.