### PR TITLE
CSS fixes on contrib, button, erp detail view.

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -4878,7 +4878,7 @@ msgstr "Last update on"
 msgid "Voir l'historique"
 msgstr "View history"
 
-msgid "Desabonnez vous des mises à jour"
+msgid "Désabonnez vous des mises à jour"
 msgstr "Unsubscribe from updates"
 
 msgid ""

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -4372,7 +4372,7 @@ msgstr ""
 msgid "Voir l'historique"
 msgstr ""
 
-msgid "Desabonnez vous des mises à jour"
+msgid "Désabonnez vous des mises à jour"
 msgstr ""
 
 msgid ""

--- a/static/scss/style.scss
+++ b/static/scss/style.scss
@@ -36,6 +36,9 @@ $viewport-xl: 1200px;
 }
 
 #content {
+  .fr-btn:hover {
+    text-decoration: underline;
+  }
   .fr-btn:not(.fr-btn--secondary):not(.fr-btn--tertiary):hover {
     color: white !important;
   }
@@ -144,6 +147,7 @@ select[name='language'] {
   &-comment-block {
     p {
       margin: 0;
+      overflow-wrap: break-word;
 
       &::before {
         content: '« ';

--- a/templates/contrib/includes/nav.html
+++ b/templates/contrib/includes/nav.html
@@ -4,48 +4,48 @@
         <button class="fr-sidemenu__btn"
                 aria-controls="fr-sidemenu-wrapper"
                 aria-expanded="false">{% translate "Navigation" %}</button>
-        <div class="fr-collapse" id="fr-sidemenu-wrapper">
+        <div id="fr-sidemenu-wrapper">
             <div class="fr-sidemenu__title" id="fr-sidemenu-title">{% translate "Étapes d'ajout d'un établissement" %}</div>
             <ul class="fr-sidemenu__list">
-                <li class="fr-sidemenu__item {% if step == 1 %}fr-sidemenu__item--active{% endif %} {% if step > 1 %}is-done{% endif %}">
+                <li class="fr-sidemenu__item{% if step == 1 %} fr-sidemenu__item--active{% endif %}{% if step > 1 %} is-done{% endif %}">
                     <a class="fr-sidemenu__link"
                        {% if erp %}href="{% url 'contrib_edit_infos' erp_slug=erp.slug %}"{% else %}role="link" aria-disabled="true"{% endif %}
                        target="_self"
                        {% if step == 1 %}aria-current="page"{% endif %}>{% translate "Informations" %}</a>
                 </li>
                 {% if not erp.user or erp.user == request.user %}
-                    <li class="fr-sidemenu__item {% if step == 2 %}fr-sidemenu__item--active{% endif %} {% if step > 2 %}is-done{% endif %}">
+                    <li class="fr-sidemenu__item{% if step == 2 %} fr-sidemenu__item--active{% endif %}{% if step > 2 %} is-done{% endif %}">
                         <a class="fr-sidemenu__link"
                            {% if erp %}href="{% url 'contrib_a_propos' erp_slug=erp.slug %}"{% else %}role="link" aria-disabled="true"{% endif %}
                            target="_self"
                            {% if step == 2 %}aria-current="page"{% endif %}>{% translate "À propos" %}</a>
                     </li>
                 {% endif %}
-                <li class="fr-sidemenu__item {% if step == 3 %}fr-sidemenu__item--active{% endif %} {% if step > 3 %}is-done{% endif %}">
+                <li class="fr-sidemenu__item{% if step == 3 %} fr-sidemenu__item--active{% endif %}{% if step > 3 %} is-done{% endif %}">
                     <a class="fr-sidemenu__link"
                        {% if erp %}href="{% url 'contrib_transport' erp_slug=erp.slug %}"{% else %}role="link" aria-disabled="true"{% endif %}
                        target="_self"
                        {% if step == 3 %}aria-current="page"{% endif %}>{% translate "Accès" %}</a>
                 </li>
-                <li class="fr-sidemenu__item {% if step == 4 %}fr-sidemenu__item--active{% endif %} {% if step > 4 %}is-done{% endif %}">
+                <li class="fr-sidemenu__item{% if step == 4 %} fr-sidemenu__item--active{% endif %}{% if step > 4 %} is-done{% endif %}">
                     <a class="fr-sidemenu__link"
                        {% if erp %}href="{% url 'contrib_exterieur' erp_slug=erp.slug %}"{% else %}role="link" aria-disabled="true"{% endif %}
                        target="_self"
                        {% if step == 4 %}aria-current="page"{% endif %}>{% translate "Extérieur" %}</a>
                 </li>
-                <li class="fr-sidemenu__item  {% if step == 5 %}fr-sidemenu__item--active{% endif %} {% if step > 5 %}is-done{% endif %}">
+                <li class="fr-sidemenu__item{% if step == 5 %} fr-sidemenu__item--active{% endif %}{% if step > 5 %} is-done{% endif %}">
                     <a class="fr-sidemenu__link"
                        {% if erp %}href="{% url 'contrib_entree' erp_slug=erp.slug %}"{% else %}role="link" aria-disabled="true"{% endif %}
                        target="_self"
                        {% if step == 5 %}aria-current="page"{% endif %}>{% translate "Entrée" %}</a>
                 </li>
-                <li class="fr-sidemenu__item {% if step == 6 %}fr-sidemenu__item--active{% endif %} {% if step > 6 %}is-done{% endif %}">
+                <li class="fr-sidemenu__item{% if step == 6 %} fr-sidemenu__item--active{% endif %}{% if step > 6 %} is-done{% endif %}">
                     <a class="fr-sidemenu__link"
                        {% if erp %}href="{% url 'contrib_accueil' erp_slug=erp.slug %}"{% else %}role="link" aria-disabled="true"{% endif %}
                        target="_self"
                        {% if step == 6 %}aria-current="page"{% endif %}>{% translate "Accueil et prestations" %}</a>
                 </li>
-                <li class="fr-sidemenu__item {% if step == 7 %}fr-sidemenu__item--active{% endif %} {% if step > 7 %}is-done{% endif %}">
+                <li class="fr-sidemenu__item{% if step == 7 %} fr-sidemenu__item--active{% endif %}{% if step > 7 %} is-done{% endif %}">
                     <a class="fr-sidemenu__link "
                        {% if erp %}href="{% url 'contrib_commentaire' erp_slug=erp.slug %}"{% else %}role="link" aria-disabled="true"{% endif %}
                        target="_self"

--- a/templates/erp/includes/versions_block.html
+++ b/templates/erp/includes/versions_block.html
@@ -41,7 +41,7 @@
                     <a href="{% url 'unsubscribe_erp' erp_slug=erp.slug %}"
                        class="fr-btn fr-btn--secondary fr-btn--lg"
                        title="Recevoir des notifications par email lorsque cet établissement est mis à jour">
-                        {% translate "Desabonnez vous des mises à jour" %}
+                        {% translate "Désabonnez vous des mises à jour" %}
                     </a>
                 {% else %}
                     <a href="{% url 'subscribe_erp' erp_slug=erp.slug %}"

--- a/templates/erp/includes/widget_block.html
+++ b/templates/erp/includes/widget_block.html
@@ -66,7 +66,7 @@
 
     function docopy() {
         var range = document.createRange();
-        var target = this.dataset.target;
+        var target = this.dataset.bsTarget;
         var fromElement = document.querySelector(target);
         var selection = window.getSelection();
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -64,7 +64,7 @@
                                 <img src="{% static 'img/contributeurs.png' %}"
                                      aria-hidden="true"
                                      alt=""
-                                     class="w-100">
+                                     class="w-100 fr-mb-4v">
                                 <a href="{% if request.user.is_anonymous %}{% url "django_registration_register" %}{% else %} {% url 'contrib_start' %}{% endif %}"
                                    class="fr-btn fr-btn--secondary d-block mx-auto w-100 fr-mt-auto text-center">{% translate "Rejoindre<br />la communauté" %}</a>
                             </div>


### PR DESCRIPTION
- Fix copy paste for widget code (due to migration to BS5)
- add a hover on all buttons to have consistency between link and buttons, especially on ERP detail page.
- Small work on css class, avoid spaces if no class added
- fix `Désabonnez`