### PR TITLE
Remove source filter in ERP sync

### DIFF
--- a/compte/management/commands/sync_brevo.py
+++ b/compte/management/commands/sync_brevo.py
@@ -15,7 +15,7 @@ class Command(BaseCommand):
             BrevoMailer().sync_user(user)
 
     def _sync_erps(self, since):
-        erps = Erp.objects.filter(created_at__gte=since, source=Erp.SOURCE_TALLY, import_email__isnull=False)
+        erps = Erp.objects.filter(created_at__gte=since, import_email__isnull=False)
         for erp in erps:
             BrevoMailer().sync_erp(erp)
 


### PR DESCRIPTION
When updating an existing ERP during import process, we won't set/change the source, so we should not rely on it for the sync