### PR TITLE
Fix non sense subscription date.

### DIFF
--- a/compte/views.py
+++ b/compte/views.py
@@ -15,6 +15,7 @@ from django_registration.backends.activation.views import ActivationView, Regist
 from compte import forms, service
 from compte.forms import CustomPasswordResetForm
 from compte.models import UserPreferences
+from stats.models import ChallengePlayer
 from core.mailer import BrevoMailer
 from erp import versioning
 from erp.models import Erp
@@ -305,7 +306,7 @@ def mes_abonnements(request):
 
 @login_required
 def mes_challenges(request):
-    qs = request.user.challenge_players.all().order_by("-inscriptions__inscription_date")
+    qs = ChallengePlayer.objects.filter(player=request.user).order_by("-inscription_date")
     paginator = Paginator(qs, 10)
     pager = paginator.get_page(request.GET.get("page", 1))
     return render(

--- a/templates/compte/mes_challenges.html
+++ b/templates/compte/mes_challenges.html
@@ -14,18 +14,18 @@
         {% translate "Les challenges sur lesquels vous êtes inscrit." %}
     </p>
     <ul class="list-group">
-        {% for challenge in pager %}
+        {% for challenge_sub in pager %}
             <li class="list-group-item d-lg-flex justify-content-between align-items-center shadow-sm">
                 <div class="flex-fill">
                     <div class="font-weight-bold">
-                        <a href="{{ challenge.get_absolute_url }}">{{ challenge.nom }}</a>
+                        <a href="{{ challenge_sub.challenge.get_absolute_url }}">{{ challenge_sub.challenge.nom }}</a>
                     </div>
                     <address class="mb-0">
-                        <small class="text-muted">{% blocktranslate with start=challenge.start_date|date:"d F Y" end=challenge.end_date|date:"d F Y" %}Du {{ start }} au {{ end }} inclus{% endblocktranslate %}</small>
+                        <small class="text-muted">{% blocktranslate with start=challenge_sub.challenge.start_date|date:"d F Y" end=challenge_sub.challenge.end_date|date:"d F Y" %}Du {{ start }} au {{ end }} inclus{% endblocktranslate %}</small>
                     </address>
                     <div>
                         <small class="text-success">
-                            {% translate "Inscrit depuis le" %} {{ request.user.inscriptions.last.inscription_date|date:"d F Y" }}
+                            {% translate "Inscrit depuis le" %} {{ challenge_sub.inscription_date|date:"d F Y" }}
                         </small>
                     </div>
                 </div>
@@ -33,8 +33,8 @@
                     <a class="fr-btn btn-outline-primary fr-my-2v"
                        target="_blank"
                        rel="noopener noreferrer"
-                       href="{{ challenge.get_absolute_url }}">{% translate "Voir le classement" %}</a>
-                    <form action="{% url 'challenge-unsubscription' challenge_slug=challenge.slug %}"
+                       href="{{ challenge_sub.challenge.get_absolute_url }}">{% translate "Voir le classement" %}</a>
+                    <form action="{% url 'challenge-unsubscription' challenge_slug=challenge_sub.challenge.slug %}"
                           method="post">
                         {% csrf_token %}
                         <button type="submit" class="fr-btn fr-btn--secondary">{% translate "Se désinscrire" %}</button>


### PR DESCRIPTION
Loop over challenge subscriptions instead of challenges. The way it was done, we were unable to easily get the subscription date per challenge.