### PR TITLE
Change ordering when looking for a specific place

### DIFF
--- a/api/filters.py
+++ b/api/filters.py
@@ -127,8 +127,15 @@ class ErpFilter(OrderingFilter, BaseFilterBackend):
             queryset = queryset.distinct("id", "nom")
 
         if not ordered:
-            ordering = self.get_ordering(request, queryset, view)
-            queryset = queryset.order_by(*ordering)
+            if request.GET.get("sortType") == "municipality":
+                municipality = request.query_params.get("where")
+                queryset = queryset.with_municipality_first(municipality)
+            elif request.GET.get("searchType") == "department":
+                department_code = request.query_params.get("where")
+                queryset = queryset.with_departement_first(department_code)
+            else:
+                ordering = self.get_ordering(request, queryset, view)
+                queryset = queryset.order_by(*ordering)
 
         return queryset
 

--- a/erp/managers.py
+++ b/erp/managers.py
@@ -3,7 +3,7 @@ from django.contrib.gis import measure
 from django.contrib.gis.db.models.functions import Distance
 from django.contrib.postgres import search
 from django.db import models
-from django.db.models import Count, F, Max, Q
+from django.db.models import Count, F, Max, Q, Case, When, IntegerField
 from django.db.models.functions import Length
 
 from erp import schema
@@ -110,6 +110,24 @@ class ErpQuerySet(models.QuerySet):
 
     def in_code_postal(self, commune):
         return self.filter(code_postal__in=commune.code_postaux)
+
+    def with_municipality_first(self, municipality):
+        return self.order_by(
+            Case(
+                When(commune__lower=municipality.lower(), then=0),
+                default=1,
+                output_field=IntegerField(),
+            )
+        )
+
+    def with_departement_first(self, department_code):
+        return self.order_by(
+            Case(
+                When(code_postal__startswith=department_code, then=0),
+                default=1,
+                output_field=IntegerField(),
+            )
+        )
 
     def having_a11y_data(self):
         """Filter ERPs having at least one a11y data filled in. A11y fields are defined

--- a/erp/views.py
+++ b/erp/views.py
@@ -272,6 +272,8 @@ def _get_or_create_api_key():
 
 def search(request):
     filters = _cleaned_search_params_as_dict(request.GET)
+    search_type = filters.get("search_type")
+    where_keyword = filters.get("municipality") or filters.get("code")
     base_queryset = Erp.objects.published().with_activity()
     base_queryset = base_queryset.search_what(filters.get("what"))
     queryset = _filter_erp_by_location(base_queryset, **filters)
@@ -305,6 +307,8 @@ def search(request):
         "equipments": get_equipments(),
         "zoom_level": zoom_level,
         "geojson_list": make_geojson(pager),
+        "search_type": search_type,
+        "where_keyword": where_keyword,
         "should_refresh_map_on_load": request.GET.get("search_type") != settings.IN_DEPARTMENT_SEARCH_TYPE,
     }
     return render(request, "search/results.html", context=context)

--- a/templates/common/map.html
+++ b/templates/common/map.html
@@ -10,6 +10,7 @@
      data-api-key="{{ map_api_key|default:'' }}"
      data-erp-identifier="{{ erp.uuid }}"
      data-should-refresh-on-map-load="{{ should_refresh_map_on_load|default:'True' }}"
+     {% if where and search_type %}data-sort-type="{{ search_type }}" data-where="{{ where_keyword }}"{% endif %}
      data-default-zoom="{% if zoom_level %}{{ zoom_level }}{% elif not lat and not lon %}{{ MAP_DEFAULT_ZOOM }}{% else %}{{ MAP_DEFAULT_ZOOM_LARGE_CITY }}{% endif %}">
     <script id="commune-data" type="application/json">
     {% if commune_json %}{{ commune_json | safe }}{% else %}null{% endif %}


### PR DESCRIPTION
Change ordering of the API when looking for a specific city or department. The ERPs coming from the exact location will be first.

Try to simplify the parameters of the geo.js file to make sure we don't have to pass parameters in all the functions.