### PR TITLE
Manage non reversible versions.

### DIFF
--- a/erp/management/commands/cancel_user_modifications.py
+++ b/erp/management/commands/cancel_user_modifications.py
@@ -5,6 +5,8 @@ from django.db.models import Q
 from reversion.models import Version
 
 from erp.models import Accessibilite, Erp
+from django.db.utils import IntegrityError
+from reversion.errors import RevertError
 
 
 class Command(BaseCommand):
@@ -64,7 +66,14 @@ class Command(BaseCommand):
 
             if self.should_write:
                 print(f"Reverting {version_to_revert_to.revision.__dict__} ...")
-                version_to_revert_to.revision.revert()
+                try:
+                    version_to_revert_to.revision.revert()
+                except IntegrityError:
+                    print("... Cannot be reverted due to accessibility inconsistencies.")
+                    continue
+                except RevertError:
+                    print("... Cannot be reverted, old version not valid anymore.")
+                    continue
                 print("... Reverted.")
             else:
                 print(f"Would have reverted {version_to_revert_to.revision}")


### PR DESCRIPTION
The target version may be obsolete, non-compliant with the current data model, and therefore not reversible.
Additionally, the absence of consistency checks in the old version could be another reason why reverting to it is not possible.

These cases should be ignored.