### PR TITLE
[Frontend] Accessibility - Activity filter fix for keyboard navigation

### DIFF
--- a/static/js/ui/AutocompleteActivity.js
+++ b/static/js/ui/AutocompleteActivity.js
@@ -41,7 +41,7 @@ document.addEventListener('DOMContentLoaded', () => {
       return exactResults.concat(otherKeywordResults)
     },
     renderResult: (result, props) => {
-      const active = props['aria-bs-selected'] ? 'active' : ''
+      const active = props['aria-selected'] ? 'active' : ''
       return `
         <li class="list-group-item a4a-autocomplete-result ${active}" ${props}>
           ${result.name}


### PR DESCRIPTION
### Description
- Activity filter autocomplete list not navigable with keyboard (up/down arrow) as opposed to the City filter that works wel

### Ticket
- https://trello.com/c/2OBT6Oyg/2122-corrigez-filtre-activit%C3%A9-pour-quil-fonctionne-au-clavier