### PR TITLE
Fix profanity check for not authenticated user

### DIFF
--- a/tests/erp/test_browser.py
+++ b/tests/erp/test_browser.py
@@ -776,9 +776,10 @@ def test_add_erp_with_profanities(client):
 
     client.post(
         reverse("contrib_commentaire", kwargs={"erp_slug": erp.slug}),
-        data={"labels_autre": "barrez-vous, cons de mimes", "commentaire": "foo"},
+        data={"labels": ["th"], "labels_autre": "barrez-vous, cons de mimes", "commentaire": "foo"},
         follow=True,
     )
+
     accessibilite = erp.accessibilite
     assert not accessibilite.labels_autre, "Comment with profanities should not be stored"
 


### PR DESCRIPTION
Previously the profanity check was done during the form.is_valid() call, but at this point the user can be non authenticated. Move the profanity check to the save() method, after a potential redirection to the login form, so that the user is always authenticated on save().