### PR TITLE
Use default policy

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -52,13 +52,6 @@ CSP_DEFAULT_SRC = (
     "wss://client.relay.crisp.chat",
     "wss://stream.relay.crisp.chat",
     "*.acceslibre.info",
-)
-CSP_SCRIPT_SRC = (
-    "'self'",
-    "*.posthog.com",
-)
-CSP_CONNECT_SRC = (
-    "'self'",
     "*.posthog.com",
 )
 


### PR DESCRIPTION
Adding a connect_src was breaking the fallback on default_src.