### PR TITLE
[Frontend] Leaflet buttons background-color hover,focus fix

### DIFF
--- a/static/scss/_leaflet.scss
+++ b/static/scss/_leaflet.scss
@@ -19,3 +19,8 @@
     background-image: none;
   }
 }
+
+.leaflet-bar a:hover,
+.leaflet-bar a:focus {
+  background-color: #f4f4f4 !important;
+}


### PR DESCRIPTION
### Description
Leaflet button styles were overridden by the DSFR which caused the button to be transparent when being hovered and focused