### PR TITLE
[Frontend] Widget edge case aria-haspopup fix

### DIFF
--- a/erp/views.py
+++ b/erp/views.py
@@ -436,7 +436,7 @@ def erp_details(request, commune, erp_slug, activite_slug=None):
         ]
     # NOTE: if the widget code is edited it should be also reflected in metabase
     widget_tag = f"""<div id="widget-a11y-container" data-pk="{erp.uuid}" data-baseurl="{settings.SITE_ROOT_URL}"></div>\n
-<a href="#" aria-haspopup="dialog" data-erp-pk="{erp.uuid}" aria-controls="dialog">{translate("Accessibilité")}</a>
+<a href="#" aria-haspopup="dialog" data-erp-pk="{erp.uuid}" aria-controls="dialog" data-owner="acceslibre">{translate("Accessibilité")}</a>
 <script src="{url_widget_js}" type="text/javascript" async="true"></script>"""
 
     erp_image_id = None

--- a/static/js/widget.js
+++ b/static/js/widget.js
@@ -103,7 +103,10 @@
   }
 
   function loadTriggers() {
-    const triggers = document.querySelectorAll('[aria-haspopup="dialog"][data-owner="acceslibre"]')
+    const oldSelector = document.querySelectorAll('[aria-haspopup="dialog"]')
+    const newSelector = document.querySelectorAll('[aria-haspopup="dialog"][data-owner="acceslibre"]')
+    const triggers = newSelector.length > 0 ? newSelector : oldSelector
+
     triggers.forEach((trigger) => {
       var dialog = null
       if (triggers.length == 1) {

--- a/static/js/widget.js
+++ b/static/js/widget.js
@@ -103,7 +103,7 @@
   }
 
   function loadTriggers() {
-    const triggers = document.querySelectorAll('[aria-haspopup="dialog"]')
+    const triggers = document.querySelectorAll('[aria-haspopup="dialog"][data-owner="acceslibre"]')
     triggers.forEach((trigger) => {
       var dialog = null
       if (triggers.length == 1) {

--- a/templates/erp/includes/widget_block.html
+++ b/templates/erp/includes/widget_block.html
@@ -52,7 +52,8 @@
                        href="#"
                        data-bs-dismiss="modal"
                        aria-haspopup="dialog"
-                       aria-controls="dialog">{% translate "Tester le widget" %}</a>
+                       aria-controls="dialog"
+                       data-owner="acceslibre">{% translate "Tester le widget" %}</a>
                     <button type="button"
                             class="fr-btn fr-btn--secondary"
                             data-bs-dismiss="modal">{% translate "Fermer" %}</button>


### PR DESCRIPTION
# Description
Some partners have issues integrating the widget because a query selector is too wide and selecting THEIR components instead of ours.
The solution is to add a differentiator such as data-owner="acceslibre" and add this to the selector.
Careful to the retrocompatibility, old scripts still need to work on the partner's end

## Trello ticket
- https://trello.com/c/c1PJdnnk/2361-pb-li%C3%A9-%C3%A0-laccess-widget