### PR TITLE
[Backend][Frontend] Step 2 fixes and logic updated

### DIFF
--- a/erp/views.py
+++ b/erp/views.py
@@ -840,7 +840,10 @@ def contrib_admin_infos(request):
 def contrib_edit_infos(request, erp_slug):
     erp = get_object_or_404(Erp, slug=erp_slug)
     initial = {"lat": Decimal(erp.geom.y), "lon": Decimal(erp.geom.x)}
-    if erp.user_id == request.user.id:
+    is_erp_owner = erp.user_id == request.user.id
+    is_from_import_and_has_no_user = erp.user_id is None and erp.user_type == "system"
+
+    if is_erp_owner or is_from_import_and_has_no_user:
         libelle_next = schema.SECTION_A_PROPOS
         next_route = "contrib_a_propos"
     else:
@@ -907,6 +910,9 @@ def contrib_edit_infos(request, erp_slug):
 def contrib_a_propos(request, erp_slug):
     erp = get_object_or_404(Erp, slug=erp_slug)
     initial = {"user_type": erp.user_type or Erp.USER_ROLE_PUBLIC}
+    is_erp_owner = erp.user_id == request.user.id
+    is_from_import_and_has_no_user = erp.user_id is None and erp.user_type == "system"
+
     if request.method == "POST":
         if erp.has_accessibilite():
             accessibilite = erp.accessibilite
@@ -943,7 +949,8 @@ def contrib_a_propos(request, erp_slug):
             "current_step_url": reverse("contrib_a_propos", kwargs={"erp_slug": erp.slug}),
             "erp": erp,
             "form": form,
-            "is_erp_owner": erp.user_id == request.user.pk,
+            "is_erp_owner": is_erp_owner,
+            "is_from_import_and_has_no_user": is_from_import_and_has_no_user,
             "publier_route": reverse("contrib_publication", kwargs={"erp_slug": erp.slug}),
             "page_type": "contrib-form",
         },

--- a/templates/contrib/2-a-propos.html
+++ b/templates/contrib/2-a-propos.html
@@ -29,12 +29,13 @@
 {% block fields_content %}
     <div class="contrib-inputs-section-wrapper">
         <div class="contrib-inputs-section fr-py-3w fr-px-4w">
-            {% if is_erp_owner %}
+            {% if is_erp_owner or is_from_import_and_has_no_user %}
                 {% include "fields/boolradio.html" with field=form.user_type key="user_type" %}
             {% else %}
                 <fieldset disabled aria-describedby="user-type-readonly-notice">
                     {% include "fields/boolradio.html" with field=form.user_type key="user_type" %}
                 </fieldset>
+                <input type="hidden" name="user_type" value="{{ form.user_type.value }}" />
                 <p id="user-type-readonly-notice" class="fr-hint-text">
                     {% translate "Ce champ ne peut être modifié que par le contributeur principal de cet établissement." %}
                 </p>


### PR DESCRIPTION
# Description
- Step 2 (A propos) should be accessible :
  - if the ERP has no owner and is from import
  - or if the ERP owner is the current user

The user_type was also not sent to the backend anymore because "disabled" fields are not sent, the solution is to add an hidden input.

# Ticket
https://trello.com/c/E99OJ9wt/2550-quand-il-y-a-un-user-sur-une-fiche-ne-pas-donner-acc%C3%A8s-%C3%A0-l%C3%A9tape-2